### PR TITLE
[add/#13] add opacity color

### DIFF
--- a/app/src/main/java/com/byeboo/app/core/designsystem/ui/theme/Color.kt
+++ b/app/src/main/java/com/byeboo/app/core/designsystem/ui/theme/Color.kt
@@ -61,19 +61,19 @@ val black = Color(0xFF000000)
 val white = Color(0xFFFFFFFF)
 
 // opacity
-val black80 = black.copy(alpha = 0.8f)
-val black50 = black.copy(alpha = 0.5f)
+val blackAlpha80 = black.copy(alpha = 0.8f)
+val blackAlpha50 = black.copy(alpha = 0.5f)
 
-val white50 = white.copy(alpha = 0.5f)
-val white10 = white.copy(alpha = 0.1f)
+val whiteAlpha50 = white.copy(alpha = 0.5f)
+val whiteAlpha10 = white.copy(alpha = 0.1f)
 
-val primary300_20 = primary300.copy(alpha = 0.2f)
-val primary50_50 = primary50.copy(alpha = 0.5f)
+val primary300Alpha20 = primary300.copy(alpha = 0.2f)
+val primary50Alpha50 = primary50.copy(alpha = 0.5f)
 
-val secondary300_30 = secondary300.copy(alpha = 0.3f)
-val secondary300_10 = secondary300.copy(alpha = 0.1f)
+val secondary300Alpha30 = secondary300.copy(alpha = 0.3f)
+val secondary300Alpha10 = secondary300.copy(alpha = 0.1f)
 
-val gray900_80 = gray900.copy(alpha = 0.8f)
+val gray900Alpha80 = gray900.copy(alpha = 0.8f)
 
 @Stable
 class ByeBooColors(
@@ -113,15 +113,15 @@ class ByeBooColors(
     gray900: Color,
     black: Color,
     white: Color,
-    black80: Color,
-    black50: Color,
-    white50: Color,
-    white10: Color,
-    primary300_20: Color,
-    primary50_50: Color,
-    secondary300_30: Color,
-    secondary300_10: Color,
-    gray900_80: Color,
+    blackAlpha80: Color,
+    blackAlpha50: Color,
+    whiteAlpha50: Color,
+    whiteAlpha10: Color,
+    primary300Alpha20: Color,
+    primary50Alpha50: Color,
+    secondary300Alpha30: Color,
+    secondary300Alpha10: Color,
+    gray900Alpha80: Color,
     isLight: Boolean
 ) {
     var primary50 by mutableStateOf(primary50)
@@ -196,23 +196,23 @@ class ByeBooColors(
         private set
     var white by mutableStateOf(white)
         private set
-    var black80 by mutableStateOf(black80)
+    var blackAlpha80 by mutableStateOf(blackAlpha80)
         private set
-    var black50 by mutableStateOf(black50)
+    var blackAlpha50 by mutableStateOf(blackAlpha50)
         private set
-    var white50 by mutableStateOf(white50)
+    var whiteAlpha50 by mutableStateOf(whiteAlpha50)
         private set
-    var white10 by mutableStateOf(white10)
+    var whiteAlpha10 by mutableStateOf(whiteAlpha10)
         private set
-    var primary300_20 by mutableStateOf(primary300_20)
+    var primary300Alpha20 by mutableStateOf(primary300Alpha20)
         private set
-    var primary50_50 by mutableStateOf(primary50_50)
+    var primary50Alpha50 by mutableStateOf(primary50Alpha50)
         private set
-    var secondary300_30 by mutableStateOf(secondary300_30)
+    var secondary300Alpha30 by mutableStateOf(secondary300Alpha30)
         private set
-    var secondary300_10 by mutableStateOf(secondary300_10)
+    var secondary300Alpha10 by mutableStateOf(secondary300Alpha10)
         private set
-    var gray900_80 by mutableStateOf(gray900_80)
+    var gray900Alpha80 by mutableStateOf(gray900Alpha80)
         private set
     var isLight by mutableStateOf(isLight)
 
@@ -253,15 +253,15 @@ class ByeBooColors(
         gray900,
         black,
         white,
-        black80,
-        black50,
-        white50,
-        white10,
-        primary300_20,
-        primary50_50,
-        secondary300_30,
-        secondary300_10,
-        gray900_80,
+        blackAlpha80,
+        blackAlpha50,
+        whiteAlpha50,
+        whiteAlpha10,
+        primary300Alpha20,
+        primary50Alpha50,
+        secondary300Alpha30,
+        secondary300Alpha10,
+        gray900Alpha80,
         isLight
     )
 
@@ -302,15 +302,15 @@ class ByeBooColors(
         gray900 = colors.gray900
         black = colors.black
         white = colors.white
-        black80 = colors.black80
-        black50 = colors.black50
-        white50 = colors.white50
-        white10 = colors.white10
-        primary300_20 = colors.primary300_20
-        primary50_50 = colors.primary50_50
-        secondary300_30 = colors.secondary300_30
-        secondary300_10 = colors.secondary300_10
-        gray900_80 = colors.gray900_80
+        blackAlpha80 = colors.blackAlpha80
+        blackAlpha50 = colors.blackAlpha50
+        whiteAlpha50 = colors.whiteAlpha50
+        whiteAlpha10 = colors.whiteAlpha10
+        primary300Alpha20 = colors.primary300Alpha20
+        primary50Alpha50 = colors.primary50Alpha50
+        secondary300Alpha30 = colors.secondary300Alpha30
+        secondary300Alpha10 = colors.secondary300Alpha10
+        gray900Alpha80 = colors.gray900Alpha80
         isLight = colors.isLight
     }
 }
@@ -352,15 +352,15 @@ fun ByeBooDarkColors(
     Gray900: Color = gray900,
     Black: Color = black,
     White: Color = white,
-    Black80: Color = black80,
-    Black50: Color = black50,
-    White50: Color = white50,
-    White10: Color = white10,
-    Primary300_20: Color = primary300_20,
-    Primary50_50: Color = primary50_50,
-    Secondary300_30: Color = secondary300_30,
-    Secondary300_10: Color = secondary300_10,
-    Gray900_80: Color = gray900_80,
+    BlackAlpha80: Color = blackAlpha80,
+    BlackAlpha50: Color = blackAlpha50,
+    WhiteAlpha50: Color = whiteAlpha50,
+    WhiteAlpha10: Color = whiteAlpha10,
+    Primary300Alpha20: Color = primary300Alpha20,
+    Primary50Alpha50: Color = primary50Alpha50,
+    Secondary300Alpha30: Color = secondary300Alpha30,
+    Secondary300Alpha10: Color = secondary300Alpha10,
+    Gray900Alpha80: Color = gray900Alpha80,
 ) = ByeBooColors(
     Primary50,
     Primary100,
@@ -398,14 +398,14 @@ fun ByeBooDarkColors(
     Gray900,
     Black,
     White,
-    Black80,
-    Black50,
-    White50,
-    White10,
-    Primary300_20,
-    Primary50_50,
-    Secondary300_30,
-    Secondary300_10,
-    Gray900_80,
+    BlackAlpha80,
+    BlackAlpha50,
+    WhiteAlpha50,
+    WhiteAlpha10,
+    Primary300Alpha20,
+    Primary50Alpha50,
+    Secondary300Alpha30,
+    Secondary300Alpha10,
+    Gray900Alpha80,
     isLight = true
 )

--- a/app/src/main/java/com/byeboo/app/core/designsystem/ui/theme/Color.kt
+++ b/app/src/main/java/com/byeboo/app/core/designsystem/ui/theme/Color.kt
@@ -61,7 +61,19 @@ val black = Color(0xFF000000)
 val white = Color(0xFFFFFFFF)
 
 // opacity
-val black50 = Color(0x80000000)
+val black80 = black.copy(alpha = 0.8f)
+val black50 = black.copy(alpha = 0.5f)
+
+val white50 = white.copy(alpha = 0.5f)
+val white10 = white.copy(alpha = 0.1f)
+
+val primary300_20 = primary300.copy(alpha = 0.2f)
+val primary50_50 = primary50.copy(alpha = 0.5f)
+
+val secondary300_30 = secondary300.copy(alpha = 0.3f)
+val secondary300_10 = secondary300.copy(alpha = 0.1f)
+
+val gray900_80 = gray900.copy(alpha = 0.8f)
 
 @Stable
 class ByeBooColors(
@@ -101,7 +113,15 @@ class ByeBooColors(
     gray900: Color,
     black: Color,
     white: Color,
+    black80: Color,
     black50: Color,
+    white50: Color,
+    white10: Color,
+    primary300_20: Color,
+    primary50_50: Color,
+    secondary300_30: Color,
+    secondary300_10: Color,
+    gray900_80: Color,
     isLight: Boolean
 ) {
     var primary50 by mutableStateOf(primary50)
@@ -176,7 +196,23 @@ class ByeBooColors(
         private set
     var white by mutableStateOf(white)
         private set
+    var black80 by mutableStateOf(black80)
+        private set
     var black50 by mutableStateOf(black50)
+        private set
+    var white50 by mutableStateOf(white50)
+        private set
+    var white10 by mutableStateOf(white10)
+        private set
+    var primary300_20 by mutableStateOf(primary300_20)
+        private set
+    var primary50_50 by mutableStateOf(primary50_50)
+        private set
+    var secondary300_30 by mutableStateOf(secondary300_30)
+        private set
+    var secondary300_10 by mutableStateOf(secondary300_10)
+        private set
+    var gray900_80 by mutableStateOf(gray900_80)
         private set
     var isLight by mutableStateOf(isLight)
 
@@ -217,7 +253,15 @@ class ByeBooColors(
         gray900,
         black,
         white,
+        black80,
         black50,
+        white50,
+        white10,
+        primary300_20,
+        primary50_50,
+        secondary300_30,
+        secondary300_10,
+        gray900_80,
         isLight
     )
 
@@ -258,7 +302,15 @@ class ByeBooColors(
         gray900 = colors.gray900
         black = colors.black
         white = colors.white
+        black80 = colors.black80
         black50 = colors.black50
+        white50 = colors.white50
+        white10 = colors.white10
+        primary300_20 = colors.primary300_20
+        primary50_50 = colors.primary50_50
+        secondary300_30 = colors.secondary300_30
+        secondary300_10 = colors.secondary300_10
+        gray900_80 = colors.gray900_80
         isLight = colors.isLight
     }
 }
@@ -300,7 +352,15 @@ fun ByeBooDarkColors(
     Gray900: Color = gray900,
     Black: Color = black,
     White: Color = white,
-    Black50: Color = black50
+    Black80: Color = black80,
+    Black50: Color = black50,
+    White50: Color = white50,
+    White10: Color = white10,
+    Primary300_20: Color = primary300_20,
+    Primary50_50: Color = primary50_50,
+    Secondary300_30: Color = secondary300_30,
+    Secondary300_10: Color = secondary300_10,
+    Gray900_80: Color = gray900_80,
 ) = ByeBooColors(
     Primary50,
     Primary100,
@@ -338,6 +398,14 @@ fun ByeBooDarkColors(
     Gray900,
     Black,
     White,
+    Black80,
     Black50,
+    White50,
+    White10,
+    Primary300_20,
+    Primary50_50,
+    Secondary300_30,
+    Secondary300_10,
+    Gray900_80,
     isLight = true
 )

--- a/app/src/main/java/com/byeboo/app/core/designsystem/ui/theme/TypoGraphy.kt
+++ b/app/src/main/java/com/byeboo/app/core/designsystem/ui/theme/TypoGraphy.kt
@@ -48,8 +48,8 @@ class ByeBooTypography internal constructor(
     body3: TextStyle,
     body4: TextStyle,
     body5: TextStyle,
-    body6: TextStyle,
-    body7: TextStyle
+    cap1: TextStyle,
+    cap2: TextStyle
 ) {
     var head1 by mutableStateOf(head1)
         private set
@@ -73,9 +73,9 @@ class ByeBooTypography internal constructor(
         private set
     var body5 by mutableStateOf(body5)
         private set
-    var body6 by mutableStateOf(body6)
+    var cap1 by mutableStateOf(cap1)
         private set
-    var body7 by mutableStateOf(body7)
+    var cap2 by mutableStateOf(cap2)
         private set
 
     fun copy(): ByeBooTypography = ByeBooTypography(
@@ -90,8 +90,8 @@ class ByeBooTypography internal constructor(
         body3 = body3,
         body4 = body4,
         body5 = body5,
-        body6 = body6,
-        body7 = body7
+        cap1 = cap1,
+        cap2 = cap2
     )
 
     fun update(typography: ByeBooTypography) {
@@ -106,8 +106,8 @@ class ByeBooTypography internal constructor(
         body3 = typography.body3
         body4 = typography.body4
         body5 = typography.body5
-        body6 = typography.body6
-        body7 = typography.body7
+        cap1 = typography.cap1
+        cap2 = typography.cap2
     }
 }
 
@@ -118,49 +118,49 @@ fun ByeBooTypography(): ByeBooTypography {
             fontFamily = suitSemiBold,
             fontSize = 24.sp,
             lineHeight = 31.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         head2 = ByeBooTextStyle(
             fontFamily = suitMedium,
             fontSize = 22.sp,
             lineHeight = 26.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         sub1 = ByeBooTextStyle(
             fontFamily = suitSemiBold,
             fontSize = 20.sp,
             lineHeight = 24.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         sub2 = ByeBooTextStyle(
             fontFamily = suitSemiBold,
             fontSize = 18.sp,
             lineHeight = 22.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         sub3 = ByeBooTextStyle(
             fontFamily = suitMedium,
             fontSize = 18.sp,
             lineHeight = 22.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         sub4 = ByeBooTextStyle(
             fontFamily = suitRegular,
             fontSize = 18.sp,
             lineHeight = 22.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         body1 = ByeBooTextStyle(
             fontFamily = suitSemiBold,
             fontSize = 16.sp,
             lineHeight = 21.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         body2 = ByeBooTextStyle(
             fontFamily = suitMedium,
             fontSize = 16.sp,
             lineHeight = 21.sp,
-            letterSpacing = (-1).em
+            letterSpacing = 0.em
         ),
         body3 = ByeBooTextStyle(
             fontFamily = suitRegular,
@@ -180,13 +180,13 @@ fun ByeBooTypography(): ByeBooTypography {
             lineHeight = 18.sp,
             letterSpacing = 0.em
         ),
-        body6 = ByeBooTextStyle(
+        cap1 = ByeBooTextStyle(
             fontFamily = suitMedium,
             fontSize = 12.sp,
             lineHeight = 16.sp,
             letterSpacing = 0.em
         ),
-        body7 = ByeBooTextStyle(
+        cap2 = ByeBooTextStyle(
             fontFamily = suitRegular,
             fontSize = 12.sp,
             lineHeight = 16.sp,


### PR DESCRIPTION
## Related issue 🛠
- closed #13 

## Work Description 📝
- 컬러 시스템의 opacity 컬러 추가

## Screenshot 📸
<img width="543" alt="스크린샷 2025-07-01 오후 2 53 37" src="https://github.com/user-attachments/assets/43b5b2c1-26a4-4fea-ac22-b31d003c2473" />

## Uncompleted Tasks 😅

## PR Point 📌
변수명 확인 부탁드립니다..!
일단 스네이크 스타일이 보기 편해서 이렇게 primary300_20 스네이크 스타일로 적었는데 카멜 케이스 지키는게 더 낫겠다 싶으면 primary300Opacity20 또는 primary300Alpah20 이런 식으로 변경하겠습니다..!!
의견 적어주세요~~

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 다양한 투명도(불투명도)가 적용된 새로운 색상(blackAlpha80, blackAlpha50, whiteAlpha50, whiteAlpha10, primary300Alpha20, primary50Alpha50, secondary300Alpha30, secondary300Alpha10, gray900Alpha80)이 색상 테마에 추가되었습니다.
  * 어두운 테마와 색상 관리에서 이 새로운 색상 옵션을 사용할 수 있습니다.
  * 텍스트 스타일 이름이 body6, body7에서 cap1, cap2로 변경되었으며, 모든 텍스트 스타일의 자간(letter spacing)이 (-1).em에서 0.em으로 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->