### PR TITLE
[feat/#74] 저장된 quest 화면 api 연결

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/quest/QuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/QuestReviewState.kt
@@ -1,18 +1,18 @@
 package com.byeboo.app.presentation.quest
 
 import com.byeboo.app.core.designsystem.type.LargeTagType
-import com.byeboo.app.core.model.QuestType
 
 data class QuestReviewState(
     val questId: Long = 0,
     val stepNumber: Long = 0,
     val questNumber: Long = 0,
-    val createdAt: String = "2025.06.01.",
-    val questQuestion: String = "그 사람이 싫어하기에 내가 포기해야만 했던 일은 무엇일까?",
-    val questAnswer: String = "내 X는 질투가 너무 많았다.\n그래서 동아리를 할 수가 없었다...\n특히 솝트처럼 합숙하는 동아린\n완전 금지였다ㅠㅠ",
-    val emotion: LargeTagType = LargeTagType.EMOTION_NEUTRAL,
+    val createdAt: String = java.time.LocalDate.now().toString(),
+    val question: String = "그 사람이 싫어하기에 내가 포기해야만 했던 일은 무엇일까?",
+    val answer: String = "내 X는 질투가 너무 많았다.\n그래서 동아리를 할 수가 없었다...\n특히 솝트처럼 합숙하는 동아린\n완전 금지였다ㅠㅠ",
+    val imageUrl: String? = null,
+    val questEmotionState: String = "",
     val emotionDescription: String = "",
-    val type: QuestType = QuestType.ACTIVE
+    val selectedEmotion: LargeTagType = LargeTagType.EMOTION_NEUTRAL
 )
 
 sealed interface QuestReviewSideEffect {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/QuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/QuestReviewViewModel.kt
@@ -3,8 +3,9 @@ package com.byeboo.app.presentation.quest
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.byeboo.app.core.designsystem.type.LargeTagType
+import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -12,9 +13,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
-class QuestReviewViewModel @Inject constructor() : ViewModel() {
+class QuestReviewViewModel @Inject constructor(
+    val questRecordedDetailRepository: QuestRecordedDetailRepository
+) : ViewModel() {
     private val _uiState = MutableStateFlow(QuestReviewState())
     val uiState: StateFlow<QuestReviewState>
         get() = _uiState.asStateFlow()
@@ -35,6 +39,29 @@ class QuestReviewViewModel @Inject constructor() : ViewModel() {
     fun onCloseClick() {
         viewModelScope.launch {
             _sideEffect.emit(QuestReviewSideEffect.NavigateToQuest)
+        }
+    }
+
+    fun getQuestRecordedDetail(questId: Long) {
+        viewModelScope.launch {
+            val result = questRecordedDetailRepository.getQuestRecordedDetail(questId)
+            result.onSuccess { detail ->
+                _uiState.update {
+                    val imageURL = detail.imageUrl?.takeIf { it.toString() != "null" }?.toString()
+
+                    val newState = it.copy(
+                        stepNumber = detail.stepNumber,
+                        questNumber = detail.questNumber,
+                        createdAt = detail.createdAt,
+                        question = detail.question,
+                        answer = detail.answer,
+                        imageUrl = imageURL,
+                        selectedEmotion = LargeTagType.fromKorean(detail.questEmotionState),
+                        emotionDescription = detail.emotionDescription,
+                    )
+                    newState
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/component/QuestTitle.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/component/QuestTitle.kt
@@ -9,11 +9,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.byeboo.app.core.designsystem.component.tag.SmallTag
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun QuestTitle(
@@ -23,6 +26,9 @@ fun QuestTitle(
     questQuestion: String
 
 ) {
+    val date = remember(createdAt) {
+        LocalDate.parse(createdAt).format(DateTimeFormatter.ofPattern("yyyy. MM. dd."))
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -45,7 +51,7 @@ fun QuestTitle(
         Spacer(modifier = Modifier.height(12.dp))
 
         Text(
-            text = createdAt,
+            text = "$date",
             color = ByeBooTheme.colors.gray400,
             style = ByeBooTheme.typography.body5
         )

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
@@ -1,6 +1,5 @@
 package com.byeboo.app.presentation.quest.record
 
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -52,8 +51,6 @@ fun QuestRecordingCompleteScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(questId) {
-        Log.d("QuestScreen", "questId = $questId")  // ← 추가
-
         viewModel.setQuestId(questId)
         viewModel.getQuestRecordedDetail(questId)
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteViewModel.kt
@@ -1,6 +1,5 @@
 package com.byeboo.app.presentation.quest.record
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.core.designsystem.type.LargeTagType


### PR DESCRIPTION
## Related issue 🛠
- closed #74 

## Work Description 📝
- 저장된 quest 화면 api 연결을 했습니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] 행동형 화면은 제대로 확인을 못해봐서 아연이꺼 올리고 나서 한 번 확인해야할 듯 합니다.

## PR Point 📌

## 트러블 슈팅 💥
null 처리하는거에 문제가 조금 있었습니다..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 퀘스트 기록 상세 정보를 불러와 화면에 표시하는 기능이 추가되었습니다.
  * 퀘스트 완료 이미지와 답변, 감정 상태가 보다 직관적으로 표시됩니다.

* **개선 사항**
  * 날짜가 "yyyy. MM. dd." 형식으로 보기 좋게 표시됩니다.
  * 퀘스트 내용 표시 방식이 간소화되어 이미지와 답변이 명확하게 구분됩니다.

* **버그 수정**
  * 불필요한 로그 및 디버깅 코드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->