### PR TITLE
[Refactor/#121] UI 스크린 라우트 분리 , 자잘한 것

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestBehaviorAnswerDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestBehaviorAnswerDataSource.kt
@@ -9,7 +9,7 @@ import okhttp3.RequestBody
 import retrofit2.Response
 
 interface QuestBehaviorAnswerDataSource {
-    suspend fun postQuestSignedUrl(request: QuestSignedUrlRequestDto): BaseResponse<QuestSingedUrlResponseDto>
-    suspend fun putImageToSignedUrl(signedUrl: String, requestBody: RequestBody): Response<Unit>
-    suspend fun postQuestBehaviorAnswer(questId: Long, request: QuestBehaviorAnswerRequestDto): NullableBaseResponse<Unit>
+    suspend fun requestQuestSignedUrl(request: QuestSignedUrlRequestDto): BaseResponse<QuestSingedUrlResponseDto>
+    suspend fun uploadImageToSignedUrl(signedUrl: String, requestBody: RequestBody): Response<Unit>
+    suspend fun uploadQuestBehaviorAnswer(questId: Long, request: QuestBehaviorAnswerRequestDto): NullableBaseResponse<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestBehaviorAnswerDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestBehaviorAnswerDataSourceImpl.kt
@@ -15,18 +15,18 @@ class QuestBehaviorAnswerDataSourceImpl @Inject constructor(
     private val questBehaviorService: QuestBehaviorService
 ) : QuestBehaviorAnswerDataSource {
 
-    override suspend fun postQuestSignedUrl(request: QuestSignedUrlRequestDto): BaseResponse<QuestSingedUrlResponseDto> {
-        return questBehaviorService.postQuestSignedUrl(request = request)
+    override suspend fun requestQuestSignedUrl(request: QuestSignedUrlRequestDto): BaseResponse<QuestSingedUrlResponseDto> {
+        return questBehaviorService.requestQuestSignedUrl(request = request)
     }
 
-    override suspend fun putImageToSignedUrl(signedUrl: String, requestBody: RequestBody): Response<Unit> {
-        return questBehaviorService.putImageToUrl(signedUrl, requestBody)
+    override suspend fun uploadImageToSignedUrl(signedUrl: String, requestBody: RequestBody): Response<Unit> {
+        return questBehaviorService.uploadImageToUrl(signedUrl, requestBody)
     }
 
-    override suspend fun postQuestBehaviorAnswer(
+    override suspend fun uploadQuestBehaviorAnswer(
         questId: Long,
         request: QuestBehaviorAnswerRequestDto
     ): NullableBaseResponse<Unit> {
-        return questBehaviorService.postQuestAnswer(questId = questId, request = request)
+        return questBehaviorService.uploadQuestAnswer(questId = questId, request = request)
     }
 }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestBehaviorAnswerRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestBehaviorAnswerRepositoryImpl.kt
@@ -13,27 +13,27 @@ class QuestBehaviorAnswerRepositoryImpl @Inject constructor(
     private val questBehaviorAnswerDataSource: QuestBehaviorAnswerDataSource
 ) : QuestBehaviorAnswerRepository {
 
-    override suspend fun postQuestSignedUrl(request: SignedUrlRequestModel): Result<String> {
+    override suspend fun requestQuestSignedUrl(request: SignedUrlRequestModel): Result<String> {
         return runCatching {
-            val response = questBehaviorAnswerDataSource.postQuestSignedUrl(request.toData())
+            val response = questBehaviorAnswerDataSource.requestQuestSignedUrl(request.toData())
             response.data.signedUrl
         }
     }
 
-    override suspend fun putImageToSignedUrl(
+    override suspend fun uploadImageToSignedUrl(
         signUrl: String,
         imageBytes: ByteArray,
         contentType: String
     ): Result<Unit> {
         return runCatching {
             val body = imageBytes.toRequestBody(contentType.toMediaTypeOrNull())
-            questBehaviorAnswerDataSource.putImageToSignedUrl(signUrl, body)
+            questBehaviorAnswerDataSource.uploadImageToSignedUrl(signUrl, body)
         }
     }
 
-    override suspend fun postQuestBehaviorAnswer(questId: Long, request: BehaviorAnswerRequestModel): Result<Unit> {
+    override suspend fun uploadQuestBehaviorAnswer(questId: Long, request: BehaviorAnswerRequestModel): Result<Unit> {
         return runCatching {
-            questBehaviorAnswerDataSource.postQuestBehaviorAnswer(questId, request.toData())
+            questBehaviorAnswerDataSource.uploadQuestBehaviorAnswer(questId, request.toData())
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/data/service/quest/QuestBehaviorService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/quest/QuestBehaviorService.kt
@@ -16,18 +16,18 @@ import retrofit2.http.Url
 interface QuestBehaviorService {
 
     @POST("/api/v1/quests/images/signed-url")
-    suspend fun postQuestSignedUrl(
+    suspend fun requestQuestSignedUrl(
         @Body request: QuestSignedUrlRequestDto
     ): BaseResponse<QuestSingedUrlResponseDto>
 
     @PUT
-    suspend fun putImageToUrl(
+    suspend fun uploadImageToUrl(
         @Url presignedUrl: String,
         @Body requestBody: RequestBody
     ): Response<Unit>
 
     @POST("/api/v1/quests/{questId}/active")
-    suspend fun postQuestAnswer(
+    suspend fun uploadQuestAnswer(
         @Path("questId") questId: Long,
         @Body request: QuestBehaviorAnswerRequestDto
     ): NullableBaseResponse<Unit>

--- a/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestBehaviorAnswerRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestBehaviorAnswerRepository.kt
@@ -4,7 +4,7 @@ import com.byeboo.app.domain.model.quest.BehaviorAnswerRequestModel
 import com.byeboo.app.domain.model.quest.SignedUrlRequestModel
 
 interface QuestBehaviorAnswerRepository {
-    suspend fun postQuestSignedUrl(request: SignedUrlRequestModel): Result<String>
-    suspend fun putImageToSignedUrl(signUrl: String, imageBytes: ByteArray, contentType: String): Result<Unit>
-    suspend fun postQuestBehaviorAnswer(questId: Long, request: BehaviorAnswerRequestModel): Result<Unit>
+    suspend fun requestQuestSignedUrl(request: SignedUrlRequestModel): Result<String>
+    suspend fun uploadImageToSignedUrl(signUrl: String, imageBytes: ByteArray, contentType: String): Result<Unit>
+    suspend fun uploadQuestBehaviorAnswer(questId: Long, request: BehaviorAnswerRequestModel): Result<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/UploadImageUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/UploadImageUseCase.kt
@@ -16,11 +16,11 @@ class UploadImageUseCase @Inject constructor(
         answer: String,
         emotion: String
     ): Result<Unit> = runCatching {
-        val signedUrl = questBehaviorAnswerRepository.postQuestSignedUrl(
+        val signedUrl = questBehaviorAnswerRepository.requestQuestSignedUrl(
             SignedUrlRequestModel(contentType, imageKey)
         ).getOrThrow()
 
-        questBehaviorAnswerRepository.putImageToSignedUrl(signedUrl, imageBytes, contentType)
+        questBehaviorAnswerRepository.uploadImageToSignedUrl(signedUrl, imageBytes, contentType)
 
         val request = BehaviorAnswerRequestModel(
             answer = answer,
@@ -28,6 +28,6 @@ class UploadImageUseCase @Inject constructor(
             imageKey = imageKey
         )
 
-        questBehaviorAnswerRepository.postQuestBehaviorAnswer(questId, request)
+        questBehaviorAnswerRepository.uploadQuestBehaviorAnswer(questId, request)
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/auth/navigation/AuthNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/navigation/AuthNavigation.kt
@@ -8,7 +8,7 @@ import androidx.navigation.compose.composable
 import com.byeboo.app.core.designsystem.component.backhandler.ByeBooBackHandler
 import com.byeboo.app.core.navigation.Route
 import com.byeboo.app.presentation.auth.loading.LoadingScreen
-import com.byeboo.app.presentation.auth.onboarding.OnboardingScreen
+import com.byeboo.app.presentation.auth.onboarding.OnboardingRoute
 import com.byeboo.app.presentation.auth.userinfo.UserInfoScreen
 import kotlinx.serialization.Serializable
 
@@ -31,7 +31,7 @@ fun NavGraphBuilder.authGraph(
     padding: Dp
 ) {
     composable<Onboarding> {
-        OnboardingScreen(
+        OnboardingRoute(
             navigateToUserInfo = navigateToUserInfo,
             padding = padding
         )

--- a/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,7 +37,7 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 
 @Composable
-fun OnboardingScreen(
+fun OnboardingRoute(
     navigateToUserInfo: () -> Unit,
     padding: Dp,
     viewModel: OnboardingViewModel = hiltViewModel()
@@ -45,9 +46,6 @@ fun OnboardingScreen(
 
     val contents = viewModel.currentContents()
 
-    val pageSpace = if (pageIndex == 2) 24.dp else 16.dp
-
-    val buttonText = if (pageIndex == 2) "시작하기" else "다음으로"
 
     if (pageIndex != 0) {
         BackHandler {
@@ -56,6 +54,39 @@ fun OnboardingScreen(
     } else {
         ByeBooBackHandler()
     }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when(effect) {
+                is OnboardingSideEffect.NavigationToUserInfo -> navigateToUserInfo()
+            }
+        }
+    }
+
+    OnboardingScreen(
+        padding = padding,
+        pageIndex = pageIndex,
+        contents = contents,
+        onSkipPage = viewModel::skipPage,
+        onNextPage = viewModel::onNextPage,
+        onShowPageNumber = viewModel::showPageNumber,
+    )
+
+
+}
+
+@Composable
+private fun OnboardingScreen(
+    padding: Dp,
+    pageIndex: Int,
+    contents: List<OnboardingState>,
+    onSkipPage: () -> Unit,
+    onNextPage: () -> Unit,
+    onShowPageNumber: () -> String,
+) {
+    val pageSpace = if (pageIndex == 2) 24.dp else 16.dp
+
+    val buttonText = if (pageIndex == 2) "시작하기" else "다음으로"
 
     Box(modifier = Modifier.fillMaxSize()) {
         Image(
@@ -73,7 +104,7 @@ fun OnboardingScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = viewModel.showPageNumber(),
+                    text = onShowPageNumber(),
                     color = ByeBooTheme.colors.primary300,
                     style = ByeBooTheme.typography.body5
                 )
@@ -82,7 +113,7 @@ fun OnboardingScreen(
 
                 if (pageIndex != 2) {
                     Row(
-                        modifier = Modifier.clickable { viewModel.skipPage(navigateToUserInfo) },
+                        modifier = Modifier.clickable { onSkipPage() },
                         verticalAlignment = Alignment.CenterVertically
 
                     ) {
@@ -141,13 +172,7 @@ fun OnboardingScreen(
                     .padding(horizontal = screenWidthDp(24.dp))
                     .padding(bottom = padding),
                 buttonText = buttonText,
-                onClick = {
-                    if (pageIndex == 2) {
-                        navigateToUserInfo()
-                    } else {
-                        viewModel.nextPage()
-                    }
-                },
+                onClick = onNextPage,
                 buttonTextColor = ByeBooTheme.colors.white,
                 buttonBackgroundColor = ByeBooTheme.colors.primary300
             )

--- a/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -35,14 +36,18 @@ import com.byeboo.app.core.designsystem.component.button.ByeBooButton
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
+import kotlinx.collections.immutable.PersistentList
 
 @Composable
 fun OnboardingRoute(
     navigateToUserInfo: () -> Unit,
     padding: Dp,
+    modifier: Modifier = Modifier,
     viewModel: OnboardingViewModel = hiltViewModel()
 ) {
     val pageIndex by viewModel.pageIndex
+
+    val pageNumber = viewModel.pageNumber
 
     val contents = viewModel.currentContents()
 
@@ -66,10 +71,12 @@ fun OnboardingRoute(
     OnboardingScreen(
         padding = padding,
         pageIndex = pageIndex,
+        pageNumber = pageNumber,
         contents = contents,
         onSkipPage = viewModel::skipPage,
         onNextPage = viewModel::onNextPage,
-        onShowPageNumber = viewModel::showPageNumber,
+        //onShowPageNumber = viewModel::showPageNumber,
+        modifier = modifier,
     )
 
 
@@ -79,41 +86,43 @@ fun OnboardingRoute(
 private fun OnboardingScreen(
     padding: Dp,
     pageIndex: Int,
-    contents: List<OnboardingState>,
+    pageNumber: String,
+    contents: PersistentList<OnboardingState>,
     onSkipPage: () -> Unit,
     onNextPage: () -> Unit,
-    onShowPageNumber: () -> String,
+    //onShowPageNumber: () -> String,
+    modifier: Modifier,
 ) {
     val pageSpace = if (pageIndex == 2) 24.dp else 16.dp
 
     val buttonText = if (pageIndex == 2) "시작하기" else "다음으로"
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize()) {
         Image(
             painter = painterResource(R.drawable.img_onboarding_background),
             contentDescription = null,
             contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize()
+            modifier = modifier.fillMaxSize()
         )
         Column(
-            modifier = Modifier.padding(top = screenHeightDp(padding + 27.dp)),
+            modifier = modifier.padding(top = screenHeightDp(padding + 27.dp)),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Row(
-                modifier = Modifier.padding(horizontal = screenWidthDp(24.dp)),
+                modifier = modifier.padding(horizontal = screenWidthDp(24.dp)),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = onShowPageNumber(),
+                    text = pageNumber,
                     color = ByeBooTheme.colors.primary300,
                     style = ByeBooTheme.typography.body5
                 )
 
-                Spacer(modifier = Modifier.weight(1f))
+                Spacer(modifier = modifier.weight(1f))
 
                 if (pageIndex != 2) {
                     Row(
-                        modifier = Modifier.clickable { onSkipPage() },
+                        modifier = modifier.clickable { onSkipPage() },
                         verticalAlignment = Alignment.CenterVertically
 
                     ) {
@@ -125,22 +134,22 @@ private fun OnboardingScreen(
                             )
                         )
 
-                        Spacer(modifier = Modifier.width(screenWidthDp(4.dp)))
+                        Spacer(modifier = modifier.width(screenWidthDp(4.dp)))
 
                         Icon(
                             imageVector = ImageVector.vectorResource(id = R.drawable.ic_right),
                             contentDescription = "next",
                             tint = ByeBooTheme.colors.primary300,
-                            modifier = Modifier.size(12.dp)
+                            modifier = modifier.size(12.dp)
                         )
                     }
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = modifier.weight(1f))
 
             Column(
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .padding(horizontal = screenWidthDp(45.dp)),
                 horizontalAlignment = Alignment.CenterHorizontally
@@ -150,11 +159,11 @@ private fun OnboardingScreen(
                     Image(
                         painter = painterResource(id = content.imageRes),
                         contentDescription = "OnBoarding image",
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = modifier.fillMaxWidth(),
                         contentScale = ContentScale.FillWidth
                     )
 
-                    Spacer(modifier = Modifier.height(screenHeightDp(pageSpace)))
+                    Spacer(modifier = modifier.height(screenHeightDp(pageSpace)))
 
                     Text(
                         text = content.title,
@@ -165,10 +174,10 @@ private fun OnboardingScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = modifier.weight(1f))
 
             ByeBooButton(
-                modifier = Modifier
+                modifier = modifier
                     .padding(horizontal = screenWidthDp(24.dp))
                     .padding(bottom = padding),
                 buttonText = buttonText,
@@ -177,5 +186,13 @@ private fun OnboardingScreen(
                 buttonBackgroundColor = ByeBooTheme.colors.primary300
             )
         }
+    }
+}
+
+
+@Preview
+@Composable
+private fun OnboardingScreenPreview() {
+    ByeBooTheme {
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingState.kt
@@ -7,3 +7,7 @@ data class OnboardingState(
     val title: String,
     val imageRes: Int
 )
+
+sealed class OnboardingSideEffect {
+    object NavigationToUserInfo : OnboardingSideEffect()
+}

--- a/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingState.kt
@@ -8,6 +8,6 @@ data class OnboardingState(
     val imageRes: Int
 )
 
-sealed class OnboardingSideEffect {
-    object NavigationToUserInfo : OnboardingSideEffect()
+sealed interface OnboardingSideEffect {
+    data object NavigationToUserInfo : OnboardingSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingViewModel.kt
@@ -2,6 +2,7 @@ package com.byeboo.app.presentation.auth.onboarding
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.R
@@ -21,7 +22,10 @@ class OnboardingViewModel @Inject constructor() : ViewModel() {
     private val _sideEffect = MutableSharedFlow<OnboardingSideEffect>()
     val sideEffect = _sideEffect.asSharedFlow()
 
-    private val pages: PersistentList<List<OnboardingState>> = persistentListOf(
+    val pageNumber: String
+        get() = "${_pageIndex.intValue + 1}/${pages.size}"
+
+    private val pages: PersistentList<PersistentList<OnboardingState>> = persistentListOf(
         persistentListOf(
             OnboardingState(
                 title = "저는 당신이 털어놓은 감정을 담는 보따리,\n보리라고 해요.",
@@ -87,6 +91,6 @@ class OnboardingViewModel @Inject constructor() : ViewModel() {
         }
     }
 
-    fun currentContents(): List<OnboardingState> = pages[_pageIndex.value]
-    fun showPageNumber(): String = "${_pageIndex.intValue + 1}/${pages.size}"
+    fun currentContents(): PersistentList<OnboardingState> = pages[_pageIndex.intValue]
+
 }

--- a/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/onboarding/OnboardingViewModel.kt
@@ -3,16 +3,23 @@ package com.byeboo.app.presentation.auth.onboarding
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.byeboo.app.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor() : ViewModel() {
     private val _pageIndex = mutableIntStateOf(0)
     val pageIndex: State<Int> = _pageIndex
+
+    private val _sideEffect = MutableSharedFlow<OnboardingSideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
 
     private val pages: PersistentList<List<OnboardingState>> = persistentListOf(
         persistentListOf(
@@ -51,6 +58,17 @@ class OnboardingViewModel @Inject constructor() : ViewModel() {
         )
     )
 
+    fun onNextPage() {
+        if (_pageIndex.intValue == 2) {
+            viewModelScope.launch {
+                _sideEffect.emit(OnboardingSideEffect.NavigationToUserInfo)
+            }
+
+        } else {
+            nextPage()
+        }
+    }
+
     fun nextPage() {
         if (_pageIndex.intValue < pages.lastIndex) {
             _pageIndex.intValue += 1
@@ -63,8 +81,10 @@ class OnboardingViewModel @Inject constructor() : ViewModel() {
         }
     }
 
-    fun skipPage(navigateToUserInfo: () -> Unit) {
-        navigateToUserInfo()
+    fun skipPage() {
+        viewModelScope.launch {
+            _sideEffect.emit(OnboardingSideEffect.NavigationToUserInfo)
+        }
     }
 
     fun currentContents(): List<OnboardingState> = pages[_pageIndex.value]

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.SubcomposeAsyncImage
@@ -57,8 +58,12 @@ fun QuestBehaviorCompleteRoute(
     viewModel: QuestBehaviorViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val imageUri = uiState.selectedImageUri ?: uiState.imageUrl.takeIf { it.isNotBlank() }
-        ?.let { Uri.parse(it) }
+
+    val imageUri = when {
+        uiState.selectedImageUri != null -> uiState.selectedImageUri
+        uiState.imageUrl.isNotBlank() -> uiState.imageUrl.toUri()
+        else -> null
+    }
 
     LaunchedEffect(questId) {
         viewModel.setQuestId(questId)

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
@@ -48,8 +48,9 @@ import com.byeboo.app.presentation.quest.component.card.QuestCompleteCard
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.CreatedText
 
+
 @Composable
-fun QuestBehaviorCompleteScreen(
+fun QuestBehaviorCompleteRoute(
     questId: Long,
     navigateToQuest: () -> Unit,
     bottomPadding: Dp,
@@ -75,6 +76,21 @@ fun QuestBehaviorCompleteScreen(
 
     BackHandler { viewModel.onCloseClick() }
 
+    QuestBehaviorCompleteScreen(
+        uiState = uiState,
+        bottomPadding = bottomPadding,
+        onCloseClick = viewModel::onCloseClick,
+        imageUri = imageUri
+    )
+}
+
+@Composable
+private fun QuestBehaviorCompleteScreen(
+    uiState: QuestBehaviorState,
+    bottomPadding: Dp,
+    onCloseClick: () -> Unit,
+    imageUri: Uri?
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -90,7 +106,7 @@ fun QuestBehaviorCompleteScreen(
             tint = ByeBooTheme.colors.white,
             modifier = Modifier
                 .align(Alignment.End)
-                .clickable { viewModel.onCloseClick() }
+                .clickable { onCloseClick() }
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
@@ -55,6 +55,7 @@ fun QuestBehaviorCompleteRoute(
     questId: Long,
     navigateToQuest: () -> Unit,
     bottomPadding: Dp,
+    modifier: Modifier = Modifier,
     viewModel: QuestBehaviorViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -71,10 +72,9 @@ fun QuestBehaviorCompleteRoute(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.sideEffect.collect { effect ->
-            when (effect) {
-                is QuestBehaviorSideEffect.NavigateToQuest -> navigateToQuest()
-                else -> ""
+        viewModel.sideEffect.collect {
+            if (it is QuestBehaviorSideEffect.NavigateToQuest) {
+                navigateToQuest()
             }
         }
     }
@@ -85,7 +85,8 @@ fun QuestBehaviorCompleteRoute(
         uiState = uiState,
         bottomPadding = bottomPadding,
         onCloseClick = viewModel::onCloseClick,
-        imageUri = imageUri
+        imageUri = imageUri,
+        modifier = modifier
     )
 }
 
@@ -94,55 +95,56 @@ private fun QuestBehaviorCompleteScreen(
     uiState: QuestBehaviorState,
     bottomPadding: Dp,
     onCloseClick: () -> Unit,
-    imageUri: Uri?
+    imageUri: Uri?,
+    modifier: Modifier
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(bottom = screenHeightDp(bottomPadding))
     ) {
-        Spacer(modifier = Modifier.height(67.dp))
+        Spacer(modifier = modifier.height(67.dp))
 
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_cancel),
             contentDescription = "back button",
             tint = ByeBooTheme.colors.white,
-            modifier = Modifier
+            modifier = modifier
                 .align(Alignment.End)
                 .clickable { onCloseClick() }
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = modifier.height(16.dp))
 
         LazyColumn(
-            modifier = Modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth()
         ) {
             item {
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = modifier.height(8.dp))
 
                 QuestCompleteCard(
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = modifier.fillMaxWidth()
                 )
 
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = modifier.height(32.dp))
             }
 
             item {
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Center
                     ) {
                         SmallTag(tagText = "STEP ${uiState.stepNumber}")
 
-                        Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
+                        Spacer(modifier = modifier.width(screenWidthDp(8.dp)))
 
                         Text(
                             text = "${uiState.questNumber}번째 퀘스트",
@@ -151,11 +153,11 @@ private fun QuestBehaviorCompleteScreen(
                         )
                     }
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = modifier.height(12.dp))
 
                     CreatedText(uiState.createdAt)
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = modifier.height(12.dp))
 
                     Text(
                         text = uiState.question,
@@ -165,7 +167,7 @@ private fun QuestBehaviorCompleteScreen(
                         textAlign = TextAlign.Center
                     )
 
-                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = modifier.height(24.dp))
                 }
             }
 
@@ -174,7 +176,7 @@ private fun QuestBehaviorCompleteScreen(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Column(
-                        modifier = Modifier
+                        modifier = modifier
                             .fillMaxWidth()
                             .aspectRatio(312 / 312f)
                             .clip(RoundedCornerShape(12.dp))
@@ -188,11 +190,11 @@ private fun QuestBehaviorCompleteScreen(
                                     .diskCachePolicy(coil.request.CachePolicy.DISABLED)
                                     .build(),
                                 contentDescription = "uploaded image",
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = modifier.fillMaxSize(),
                                 contentScale = ContentScale.Crop,
                                 loading = {
                                     Box(
-                                        modifier = Modifier.fillMaxSize(),
+                                        modifier = modifier.fillMaxSize(),
                                         contentAlignment = Alignment.Center
                                     ) {
                                         CircularProgressIndicator()
@@ -203,10 +205,10 @@ private fun QuestBehaviorCompleteScreen(
                     }
 
                     if (uiState.answer.isNotBlank()) {
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Spacer(modifier = modifier.height(8.dp))
                         ContentText(uiState.answer)
                     }
-                    Spacer(modifier = Modifier.height(21.dp))
+                    Spacer(modifier = modifier.height(21.dp))
                 }
             }
 
@@ -217,7 +219,7 @@ private fun QuestBehaviorCompleteScreen(
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_change),
                         contentDescription = "title icon",
-                        modifier = Modifier.padding(end = 8.dp),
+                        modifier = modifier.padding(end = 8.dp),
                         tint = Color.Unspecified
                     )
 
@@ -228,14 +230,14 @@ private fun QuestBehaviorCompleteScreen(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = modifier.height(12.dp))
 
                 QuestEmotionDescriptionCard(
                     questEmotionDescription = uiState.emotionDescription,
                     emotionType = uiState.selectedEmotion
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = modifier.height(24.dp))
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorViewModel.kt
@@ -120,7 +120,7 @@ class QuestBehaviorViewModel @Inject constructor(
         }
     }
 
-    fun updateContent(isFocused: Boolean, text: String) {
+    fun updateContent(text: String) {
         val contentState = if (text.isEmpty()) {
             QuestWritingState.Ready
         } else {
@@ -156,16 +156,8 @@ class QuestBehaviorViewModel @Inject constructor(
     fun onQuitClick() {
         viewModelScope.launch {
             _sideEffect.emit(QuestBehaviorSideEffect.NavigateToQuest)
-
-            delay(300)
-
-            _uiState.update {
-                it.copy(
-                    selectedImageUri = null,
-                    imageCount = 0,
-                    contents = ""
-                )
-            }
+            delay(NAVIGATION_DELAY_MS)
+            clearQuestInput()
         }
     }
 
@@ -196,5 +188,9 @@ class QuestBehaviorViewModel @Inject constructor(
         viewModelScope.launch {
             _sideEffect.emit(QuestBehaviorSideEffect.NavigateToQuest)
         }
+    }
+
+    companion object {
+        private const val NAVIGATION_DELAY_MS = 300L
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
@@ -65,13 +65,11 @@ fun QuestBehaviorWritingRoute(
     navigateToQuestTip: (Long, QuestType) -> Unit,
     navigateToQuestBehaviorComplete: (Long) -> Unit,
     bottomPadding: Dp,
+    modifier: Modifier = Modifier,
     viewModel: QuestBehaviorViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    val bringIntoViewRequester = remember { BringIntoViewRequester() }
-
-    val isFocused = remember { mutableStateOf(false) }
 
     LaunchedEffect(questId) {
         viewModel.setQuestId(questId)
@@ -105,16 +103,10 @@ fun QuestBehaviorWritingRoute(
             quitButton = {
                 viewModel.onDismissModal()
                 viewModel.onQuitClick() },
-            modifier = Modifier.padding(horizontal = 24.dp)
+            modifier = modifier.padding(horizontal = 24.dp)
         )
     }
 
-    LaunchedEffect(isFocused.value) {
-        if (isFocused.value) {
-            delay(300)
-            bringIntoViewRequester.bringIntoView()
-        }
-    }
 
     BackHandler { viewModel.onBackClicked() }
 
@@ -123,8 +115,6 @@ fun QuestBehaviorWritingRoute(
         bottomPadding = bottomPadding,
         onBackClick = viewModel::onBackClicked,
         onTipClick = viewModel::onTipClick,
-        bringIntoViewRequester = bringIntoViewRequester,
-        isFocused = isFocused,
         onUpdateSelectedImage = viewModel::updateSelectedImage,
         onUpdateContent = viewModel::updateContent,
         navigateButton = viewModel::uploadImage,
@@ -136,7 +126,8 @@ fun QuestBehaviorWritingRoute(
         },
         onSelectedChanged = { isSelected ->
             viewModel.isEmotionSelected(isSelected)
-        }
+        },
+        modifier = modifier
 
     )
 
@@ -151,18 +142,27 @@ private fun QuestBehaviorWritingScreen(
     onBackClick:() -> Unit,
     onTipClick: () -> Unit,
     onUpdateSelectedImage: (Uri?) -> Unit,
-    bringIntoViewRequester: BringIntoViewRequester,
-    isFocused: MutableState<Boolean>,
     onClickCompleteButton: () -> Unit,
     onUpdateContent: (String) -> Unit,
     navigateButton: (Context) -> Unit,
     onBottomSheetDismiss: () -> Unit,
     onEmotionSelected: (LargeTagType) -> Unit,
     onSelectedChanged: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier
 ) {
     val context = LocalContext.current
     val focusManager = LocalFocusManager.current
+
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+
+    val isFocused = remember { mutableStateOf(false) }
+
+    LaunchedEffect(isFocused.value) {
+        if (isFocused.value) {
+            delay(300)
+            bringIntoViewRequester.bringIntoView()
+        }
+    }
 
     Column(
         modifier = modifier
@@ -176,7 +176,7 @@ private fun QuestBehaviorWritingScreen(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_left),
             contentDescription = "back button",
             tint = ByeBooTheme.colors.white,
-            modifier = Modifier
+            modifier = modifier
                 .padding(
                     top = screenHeightDp((27.dp) + bottomPadding), bottom = screenHeightDp(16.dp)
                 )
@@ -184,11 +184,11 @@ private fun QuestBehaviorWritingScreen(
                 .clickable { onBackClick() })
 
         LazyColumn(
-            modifier = Modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth()
         ) {
             item {
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -197,7 +197,7 @@ private fun QuestBehaviorWritingScreen(
                         tagColor = ByeBooTheme.colors.gray300
                     )
 
-                    Spacer(modifier = Modifier.width(screenWidthDp(12.dp)))
+                    Spacer(modifier = modifier.width(screenWidthDp(12.dp)))
 
                     Text(
                         text = "${uiState.stepMissionTitle}",
@@ -206,7 +206,7 @@ private fun QuestBehaviorWritingScreen(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(screenHeightDp(12.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(12.dp)))
             }
 
             item {
@@ -215,10 +215,10 @@ private fun QuestBehaviorWritingScreen(
                     color = ByeBooTheme.colors.secondary300,
                     textAlign = TextAlign.Center,
                     style = ByeBooTheme.typography.body5,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = modifier.fillMaxWidth()
                 )
 
-                Spacer(modifier = Modifier.height(screenHeightDp(12.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(12.dp)))
             }
 
             item {
@@ -227,31 +227,31 @@ private fun QuestBehaviorWritingScreen(
                     color = ByeBooTheme.colors.gray100,
                     textAlign = TextAlign.Center,
                     style = ByeBooTheme.typography.head1,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = modifier.fillMaxWidth()
                 )
 
-                Spacer(modifier = Modifier.height(screenHeightDp(25.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(25.dp)))
             }
 
             item {
                 Box(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = modifier.fillMaxWidth(),
                     contentAlignment = Alignment.Center
                 ) {
                     MiddleTag(
                         middleTagType = MiddleTagType.QUEST_TIP,
                         text = "작성 TIP",
-                        modifier = Modifier.clickable { onTipClick() })
+                        modifier = modifier.clickable { onTipClick() })
                 }
 
-                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(16.dp)))
             }
 
             item {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     MiddleTag(middleTagType = MiddleTagType.QUEST_ESSENTIAL, text = "필수")
 
-                    Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
+                    Spacer(modifier = modifier.width(screenWidthDp(8.dp)))
 
                     Text(
                         text = "사진 첨부",
@@ -259,7 +259,7 @@ private fun QuestBehaviorWritingScreen(
                         style = ByeBooTheme.typography.body2
                     )
 
-                    Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
+                    Spacer(modifier = modifier.width(screenWidthDp(8.dp)))
 
                     Text(
                         text = "(${uiState.imageCount}/1)",
@@ -268,7 +268,7 @@ private fun QuestBehaviorWritingScreen(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(screenHeightDp(8.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(8.dp)))
             }
 
             item {
@@ -279,14 +279,14 @@ private fun QuestBehaviorWritingScreen(
                     }
                 )
 
-                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(16.dp)))
             }
 
             item {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     MiddleTag(middleTagType = MiddleTagType.QUEST_OPTIONAL, text = "선택")
 
-                    Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
+                    Spacer(modifier = modifier.width(screenWidthDp(8.dp)))
 
                     Text(
                         text = "생각 적기",
@@ -295,7 +295,7 @@ private fun QuestBehaviorWritingScreen(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(screenHeightDp(8.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(8.dp)))
             }
 
             item {
@@ -313,7 +313,7 @@ private fun QuestBehaviorWritingScreen(
                         onFocusChanged = {
                             isFocused.value = it
                         },
-                        modifier = Modifier
+                        modifier = modifier
                             .fillMaxWidth()
                             .bringIntoViewRequester(bringIntoViewRequester)
                     )
@@ -321,7 +321,7 @@ private fun QuestBehaviorWritingScreen(
             }
 
             item {
-                Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
+                Spacer(modifier = modifier.height(screenHeightDp(24.dp)))
 
                 ByeBooActivationButton(
                     buttonDisableColor = ByeBooTheme.colors.whiteAlpha10,

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
@@ -1,6 +1,7 @@
 package com.byeboo.app.presentation.quest.behavior
 
 import QuestPhotoPicker
+import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -22,6 +23,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,11 +36,13 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.component.button.ByeBooActivationButton
 import com.byeboo.app.core.designsystem.component.tag.MiddleTag
 import com.byeboo.app.core.designsystem.component.tag.SmallTag
+import com.byeboo.app.core.designsystem.type.LargeTagType
 import com.byeboo.app.core.designsystem.type.MiddleTagType
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.model.quest.QuestType
@@ -54,18 +58,17 @@ import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun QuestBehaviorWritingScreen(
+fun QuestBehaviorWritingRoute(
     questId: Long,
     navigateToQuest: () -> Unit,
     navigateToQuestTip: (Long, QuestType) -> Unit,
     navigateToQuestBehaviorComplete: (Long) -> Unit,
     bottomPadding: Dp,
-    modifier: Modifier = Modifier,
-    viewModel: QuestBehaviorViewModel
+    viewModel: QuestBehaviorViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    val focusManager = LocalFocusManager.current
+
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
     val isFocused = remember { mutableStateOf(false) }
 
@@ -79,8 +82,7 @@ fun QuestBehaviorWritingScreen(
             when (it) {
                 is QuestBehaviorSideEffect.NavigateToQuest -> navigateToQuest()
                 is QuestBehaviorSideEffect.NavigateToQuestTip -> navigateToQuestTip(
-                    it.questId,
-                    it.questType
+                    it.questId, it.questType
                 )
 
                 is QuestBehaviorSideEffect.NavigateToQuestBehaviorComplete -> navigateToQuestBehaviorComplete(
@@ -98,13 +100,10 @@ fun QuestBehaviorWritingScreen(
     if (uiState.showQuitModal) {
         QuestQuitModal(
             onDismissRequest = { viewModel.onDismissModal() },
-            stayButton = {
-                viewModel.onDismissModal()
-            },
+            stayButton = { viewModel.onDismissModal() },
             quitButton = {
                 viewModel.onDismissModal()
-                viewModel.onQuitClick()
-            },
+                viewModel.onQuitClick() },
             modifier = Modifier.padding(horizontal = 24.dp)
         )
     }
@@ -117,6 +116,51 @@ fun QuestBehaviorWritingScreen(
     }
 
     BackHandler { viewModel.onBackClicked() }
+
+    QuestBehaviorWritingScreen(
+        uiState = uiState,
+        bottomPadding = bottomPadding,
+        onBackClick = viewModel::onBackClicked,
+        onTipClick = viewModel::onTipClick,
+        bringIntoViewRequester = bringIntoViewRequester,
+        isFocused = isFocused,
+        onUpdateSelectedImage = viewModel::updateSelectedImage,
+        onUpdateContent = viewModel::updateContent,
+        navigateButton = {viewModel.uploadImage(context)},
+        onClickCompleteButton = viewModel::openBottomSheet,
+        onBottomSheetDismiss = viewModel::closeBottomSheet,
+        onEmotionSelected = { selectedEmotion ->
+            viewModel.isEmotionSelected(true)
+            viewModel.updateSelectedEmotion(selectedEmotion)
+        },
+        onSelectedChanged = { isSelected ->
+            viewModel.isEmotionSelected(isSelected)
+        }
+
+    )
+
+
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun QuestBehaviorWritingScreen(
+    uiState: QuestBehaviorState,
+    bottomPadding: Dp,
+    onBackClick:() -> Unit,
+    onTipClick: () -> Unit,
+    onUpdateSelectedImage: (Uri?) -> Unit,
+    bringIntoViewRequester: BringIntoViewRequester,
+    isFocused: MutableState<Boolean>,
+    onClickCompleteButton: () -> Unit,
+    onUpdateContent: (Boolean, String) -> Unit,
+    navigateButton: () -> Unit,
+    onBottomSheetDismiss: () -> Unit,
+    onEmotionSelected: (LargeTagType) -> Unit,
+    onSelectedChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusManager = LocalFocusManager.current
 
     Column(
         modifier = modifier
@@ -132,12 +176,10 @@ fun QuestBehaviorWritingScreen(
             tint = ByeBooTheme.colors.white,
             modifier = Modifier
                 .padding(
-                    top = screenHeightDp((27.dp) + bottomPadding),
-                    bottom = screenHeightDp(16.dp)
+                    top = screenHeightDp((27.dp) + bottomPadding), bottom = screenHeightDp(16.dp)
                 )
                 .align(Alignment.Start)
-                .clickable { viewModel.onBackClicked() }
-        )
+                .clickable { onBackClick() })
 
         LazyColumn(
             modifier = Modifier.fillMaxWidth()
@@ -197,8 +239,7 @@ fun QuestBehaviorWritingScreen(
                     MiddleTag(
                         middleTagType = MiddleTagType.QUEST_TIP,
                         text = "작성 TIP",
-                        modifier = Modifier.clickable { viewModel.onTipClick() }
-                    )
+                        modifier = Modifier.clickable { onTipClick() })
                 }
 
                 Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
@@ -232,7 +273,7 @@ fun QuestBehaviorWritingScreen(
                 QuestPhotoPicker(
                     imageUrl = uiState.selectedImageUri,
                     onImageClick = { url ->
-                        viewModel.updateSelectedImage(url)
+                        onUpdateSelectedImage(url)
                     }
                 )
 
@@ -262,7 +303,7 @@ fun QuestBehaviorWritingScreen(
                         value = uiState.contents,
                         onValueChange = {
                             if (it.length <= 200) {
-                                viewModel.updateContent(isFocused = true, it)
+                                onUpdateContent(isFocused.value, it)
                             }
                         },
                         placeholder = "꼭 적지 않아도 괜찮지만, 글로 정리해보면 스스로에게 한 걸음 더 가까워질 수 있어요.",
@@ -285,8 +326,8 @@ fun QuestBehaviorWritingScreen(
                     buttonText = "완료",
                     buttonDisableTextColor = ByeBooTheme.colors.gray300,
                     onClick = {
-                        viewModel.openBottomSheet()
-                        viewModel.updateSelectedImage(uiState.selectedImageUri)
+                        onClickCompleteButton()
+                        onUpdateSelectedImage(uiState.selectedImageUri)
                     },
                     isEnabled = QuestValidator.validButton(uiState.imageCount)
                 )
@@ -295,19 +336,13 @@ fun QuestBehaviorWritingScreen(
     }
 
     ByeBooBottomSheet(
-        navigateButton = { viewModel.uploadImage(context) },
+        navigateButton = navigateButton,
         showBottomSheet = uiState.showBottomSheet,
-        onDismiss = {
-            viewModel.closeBottomSheet()
-        },
-        onEmotionSelected = { selectedEmotion ->
-            viewModel.isEmotionSelected(true)
-            viewModel.updateSelectedEmotion(selectedEmotion)
-        },
-        onSelectedChanged = { isSelected ->
-            viewModel.isEmotionSelected(isSelected)
-        },
+        onDismiss = onBottomSheetDismiss,
+        onEmotionSelected = onEmotionSelected,
+        onSelectedChanged = onSelectedChanged,
         isSelected = uiState.isEmotionSelected,
         isUploading = uiState.isUploading
     )
 }
+

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.component.button.ByeBooActivationButton
 import com.byeboo.app.core.designsystem.component.tag.MiddleTag
@@ -155,7 +154,7 @@ private fun QuestBehaviorWritingScreen(
     bringIntoViewRequester: BringIntoViewRequester,
     isFocused: MutableState<Boolean>,
     onClickCompleteButton: () -> Unit,
-    onUpdateContent: (Boolean, String) -> Unit,
+    onUpdateContent: (String) -> Unit,
     navigateButton: (Context) -> Unit,
     onBottomSheetDismiss: () -> Unit,
     onEmotionSelected: (LargeTagType) -> Unit,
@@ -306,7 +305,7 @@ private fun QuestBehaviorWritingScreen(
                         value = uiState.contents,
                         onValueChange = {
                             if (it.length <= 200) {
-                                onUpdateContent(isFocused.value, it)
+                                onUpdateContent(it)
                             }
                         },
                         placeholder = "꼭 적지 않아도 괜찮지만, 글로 정리해보면 스스로에게 한 걸음 더 가까워질 수 있어요.",

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
@@ -1,6 +1,7 @@
 package com.byeboo.app.presentation.quest.behavior
 
 import QuestPhotoPicker
+import android.content.Context
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
@@ -38,6 +39,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.component.button.ByeBooActivationButton
 import com.byeboo.app.core.designsystem.component.tag.MiddleTag
@@ -67,9 +69,9 @@ fun QuestBehaviorWritingRoute(
     viewModel: QuestBehaviorViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val context = LocalContext.current
 
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
+
     val isFocused = remember { mutableStateOf(false) }
 
     LaunchedEffect(questId) {
@@ -126,7 +128,7 @@ fun QuestBehaviorWritingRoute(
         isFocused = isFocused,
         onUpdateSelectedImage = viewModel::updateSelectedImage,
         onUpdateContent = viewModel::updateContent,
-        navigateButton = {viewModel.uploadImage(context)},
+        navigateButton = viewModel::uploadImage,
         onClickCompleteButton = viewModel::openBottomSheet,
         onBottomSheetDismiss = viewModel::closeBottomSheet,
         onEmotionSelected = { selectedEmotion ->
@@ -154,12 +156,13 @@ private fun QuestBehaviorWritingScreen(
     isFocused: MutableState<Boolean>,
     onClickCompleteButton: () -> Unit,
     onUpdateContent: (Boolean, String) -> Unit,
-    navigateButton: () -> Unit,
+    navigateButton: (Context) -> Unit,
     onBottomSheetDismiss: () -> Unit,
     onEmotionSelected: (LargeTagType) -> Unit,
     onSelectedChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     val focusManager = LocalFocusManager.current
 
     Column(
@@ -336,7 +339,7 @@ private fun QuestBehaviorWritingScreen(
     }
 
     ByeBooBottomSheet(
-        navigateButton = navigateButton,
+        navigateButton = {navigateButton(context)},
         showBottomSheet = uiState.showBottomSheet,
         onDismiss = onBottomSheetDismiss,
         onEmotionSelected = onEmotionSelected,

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
@@ -8,7 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.core.util.routeNavigation
-import com.byeboo.app.presentation.quest.behavior.QuestBehaviorCompleteScreen
+import com.byeboo.app.presentation.quest.behavior.QuestBehaviorCompleteRoute
 import com.byeboo.app.presentation.quest.behavior.QuestBehaviorViewModel
 import com.byeboo.app.presentation.quest.behavior.QuestBehaviorWritingRoute
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior.QuestBehaviorComplete
@@ -48,7 +48,7 @@ fun NavGraphBuilder.questBehaviorGraph(
             val questRecording = backStackEntry.toRoute<QuestBehaviorComplete>()
             val questId = questRecording.questId
 
-            QuestBehaviorCompleteScreen(
+            QuestBehaviorCompleteRoute(
                 viewModel = viewModel,
                 questId = questId,
                 navigateToQuest = navigateToQuest,

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
@@ -10,7 +10,7 @@ import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.core.util.routeNavigation
 import com.byeboo.app.presentation.quest.behavior.QuestBehaviorCompleteScreen
 import com.byeboo.app.presentation.quest.behavior.QuestBehaviorViewModel
-import com.byeboo.app.presentation.quest.behavior.QuestBehaviorWritingScreen
+import com.byeboo.app.presentation.quest.behavior.QuestBehaviorWritingRoute
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior.QuestBehaviorComplete
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior.QuestBehaviorWriting
 
@@ -34,7 +34,7 @@ fun NavGraphBuilder.questBehaviorGraph(
             val questRecording = backStackEntry.toRoute<QuestBehaviorWriting>()
             val questId = questRecording.questId
 
-            QuestBehaviorWritingScreen(
+            QuestBehaviorWritingRoute(
                 viewModel = viewModel,
                 questId = questId,
                 navigateToQuest = navigateToQuest,


### PR DESCRIPTION
## Related issue 🛠
- closed #121

## Work Description 📝
- QuestBehaviorWritingScreen 
- QuestBehaviorCompleteScreen
- HomeOnboardingScreen
- 멘토님 코드 리뷰 반영(repository 함수명 변경)

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## PR Point 📌

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **리팩터링**
  * 온보딩 및 퀘스트 행동 작성/완료 화면의 UI와 상태 관리 로직을 분리하여, 화면의 재사용성과 유지보수성을 향상시켰습니다.
  * 여러 컴포저블 함수가 명확한 역할을 갖도록 이름을 변경하고, 콜백과 상태를 명시적으로 전달하도록 개선했습니다.
  * 퀘스트 행동 뷰모델에서 입력 초기화 로직을 별도 함수로 분리하고, 업데이트 함수 시그니처를 단순화했습니다.

* **스타일**
  * 내부 함수 및 인터페이스 명칭이 더 직관적으로 변경되어 가독성이 향상되었습니다.

* **기타**
  * 내부 네비게이션 및 사이드 이펙트 처리가 이벤트 기반 방식으로 변경되어 안정성이 향상되었습니다.
  * 이미지 업로드 관련 메서드 명칭을 명확한 표현으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->