### PR TITLE
[feat/#135]  오프보딩 - 완료한 여정 돌아보기 UI 구현

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
@@ -9,11 +9,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
@@ -24,6 +28,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.offboarding.component.JourneyCard
 
@@ -39,6 +44,7 @@ fun OffboardingCompletedJourneyRoute(
     OffboardingCompletedJourneyScreen(
         uiState = uiState,
         bottomPadding = bottomPadding,
+        onBackClick = {},
         onJourneyCompletedCardClick = {},
         modifier = modifier
     )
@@ -48,6 +54,7 @@ fun OffboardingCompletedJourneyRoute(
 private fun OffboardingCompletedJourneyScreen(
     uiState: OffboardingCompletedJourneyState,
     bottomPadding: Dp,
+    onBackClick: () -> Unit,
     onJourneyCompletedCardClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -56,13 +63,14 @@ private fun OffboardingCompletedJourneyScreen(
             .fillMaxSize()
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(top = 67.dp, bottom = bottomPadding)
+            .verticalScroll(rememberScrollState())
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_left),
             contentDescription = "",
             modifier = Modifier
-                .fillMaxWidth()
-                .size(24.dp),
+                .size(24.dp)
+                .noRippleClickable(onClick = onBackClick),
             tint = ByeBooTheme.colors.gray50,
         )
 
@@ -90,14 +98,17 @@ private fun OffboardingCompletedJourneyScreen(
                 .padding(vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Row(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Text(
                     text = "완료",
                     color = ByeBooTheme.colors.gray300,
                     style = ByeBooTheme.typography.cap2
                 )
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.width(8.dp))
 
                 Text(
                     text = "${uiState.completed}개",
@@ -114,10 +125,6 @@ private fun OffboardingCompletedJourneyScreen(
                     chipTextColor = ByeBooTheme.colors.gray300,
                     journeyTitleTextColor = ByeBooTheme.colors.gray300,
                 )
-            }
-
-            (uiState.completedCards).forEach { card ->
-
             }
 
             if (uiState.completed == 0) {

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -118,13 +119,15 @@ private fun OffboardingCompletedJourneyScreen(
             }
 
             (uiState.completedCards).forEach { card ->
-                JourneyCard(
-                    journeyType = card.journeyType,
-                    onJourneyCardClick = onJourneyCompletedCardClick,
-                    chipBackgroundColor = ByeBooTheme.colors.whiteAlpha10,
-                    chipTextColor = ByeBooTheme.colors.gray300,
-                    journeyTitleTextColor = ByeBooTheme.colors.gray300,
-                )
+                key (card){
+                    JourneyCard(
+                        journeyType = card.journeyType,
+                        onJourneyCardClick = onJourneyCompletedCardClick,
+                        chipBackgroundColor = ByeBooTheme.colors.whiteAlpha10,
+                        chipTextColor = ByeBooTheme.colors.gray300,
+                        journeyTitleTextColor = ByeBooTheme.colors.gray300,
+                    )
+                }
             }
 
             if (uiState.completed == 0) {

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
@@ -1,0 +1,137 @@
+package com.byeboo.app.presentation.offboarding.offboardingCompletedJourney
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.byeboo.app.R
+import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import com.byeboo.app.core.util.screenWidthDp
+import com.byeboo.app.presentation.offboarding.component.JourneyCard
+
+@Composable
+fun OffboardingCompletedJourneyRoute(
+    bottomPadding: Dp,
+    modifier: Modifier = Modifier,
+    viewModel: OffboardingCompletedJourneyViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // TODO: 클릭 시 이동 관련 추후에 구현할 예정
+    OffboardingCompletedJourneyScreen(
+        uiState = uiState,
+        bottomPadding = bottomPadding,
+        onJourneyCompletedCardClick = {},
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun OffboardingCompletedJourneyScreen(
+    uiState: OffboardingCompletedJourneyState,
+    bottomPadding: Dp,
+    onJourneyCompletedCardClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = screenWidthDp(24.dp))
+            .padding(top = 67.dp, bottom = bottomPadding)
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_left),
+            contentDescription = "",
+            modifier = Modifier
+                .fillMaxWidth()
+                .size(24.dp),
+            tint = ByeBooTheme.colors.gray50,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(
+            text = "내가 완료한 여정이에요.",
+            color = ByeBooTheme.colors.gray50,
+            style = ByeBooTheme.typography.head1,
+        )
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            thickness = 1.dp,
+            color = ByeBooTheme.colors.whiteAlpha10
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "완료",
+                    color = ByeBooTheme.colors.gray300,
+                    style = ByeBooTheme.typography.cap2
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "${uiState.completed}개",
+                    color = ByeBooTheme.colors.gray500,
+                    style = ByeBooTheme.typography.body2
+                )
+            }
+
+            (uiState.completedCards).forEach { card ->
+                JourneyCard(
+                    journeyType = card.journeyType,
+                    onJourneyCardClick = onJourneyCompletedCardClick,
+                    chipBackgroundColor = ByeBooTheme.colors.whiteAlpha10,
+                    chipTextColor = ByeBooTheme.colors.gray300,
+                    journeyTitleTextColor = ByeBooTheme.colors.gray300,
+                )
+            }
+
+            (uiState.completedCards).forEach { card ->
+
+            }
+
+            if (uiState.completed == 0) {
+
+                Spacer(modifier = Modifier.height(188.5.dp))
+
+                Text(
+                    text = "아직 완료된 여정이 없어요!",
+                    color = ByeBooTheme.colors.gray300,
+                    style = ByeBooTheme.typography.body3,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyScreen.kt
@@ -108,7 +108,7 @@ private fun OffboardingCompletedJourneyScreen(
                     style = ByeBooTheme.typography.cap2
                 )
 
-                Spacer(modifier = Modifier.width(8.dp))
+                Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
 
                 Text(
                     text = "${uiState.completed}개",
@@ -128,7 +128,6 @@ private fun OffboardingCompletedJourneyScreen(
             }
 
             if (uiState.completed == 0) {
-
                 Spacer(modifier = Modifier.height(188.5.dp))
 
                 Text(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyState.kt
@@ -1,0 +1,20 @@
+package com.byeboo.app.presentation.offboarding.offboardingCompletedJourney
+
+import com.byeboo.app.domain.model.offboarding.JourneyType
+import com.byeboo.app.presentation.offboarding.offboardingnewjourney.JourneyStatus
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+
+data class OffboardingCompletedJourneyState(
+    val journeyCards: ImmutableList<JourneyCards> = persistentListOf()
+) {
+    val completed: Int = 0
+    val completedCards: ImmutableList<JourneyCards>
+        get() = journeyCards.filter { it.status == JourneyStatus.COMPLETED }.toImmutableList()
+}
+
+data class JourneyCards(
+    val journeyType: JourneyType,
+    val status: JourneyStatus
+)

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingCompletedJourney/OffboardingCompletedJourneyViewModel.kt
@@ -1,0 +1,14 @@
+package com.byeboo.app.presentation.offboarding.offboardingCompletedJourney
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class OffboardingCompletedJourneyViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = MutableStateFlow(OffboardingCompletedJourneyState())
+    val uiState: StateFlow<OffboardingCompletedJourneyState> = _uiState.asStateFlow()
+}

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingnewjourney/OffboardingNewJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingnewjourney/OffboardingNewJourneyScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -134,13 +135,15 @@ private fun OffboardingNewJourneyScreen(
             }
 
             (uiState.uncompletedCards).forEach { card ->
-                JourneyCard(
-                    journeyType = card.journeyType,
-                    onJourneyCardClick = onJourneyUncompletedCardClick,
-                    chipBackgroundColor = ByeBooTheme.colors.primary300,
-                    chipTextColor = ByeBooTheme.colors.white,
-                    journeyTitleTextColor = ByeBooTheme.colors.gray50,
-                )
+                key(card) {
+                    JourneyCard(
+                        journeyType = card.journeyType,
+                        onJourneyCardClick = onJourneyUncompletedCardClick,
+                        chipBackgroundColor = ByeBooTheme.colors.primary300,
+                        chipTextColor = ByeBooTheme.colors.white,
+                        journeyTitleTextColor = ByeBooTheme.colors.gray50,
+                    )
+                }
             }
 
             PreparingCard()
@@ -180,13 +183,15 @@ private fun OffboardingNewJourneyScreen(
             }
 
             (uiState.completedCards).forEach { card ->
-                JourneyCard(
-                    journeyType = card.journeyType,
-                    onJourneyCardClick = onJourneyCompletedCardClick,
-                    chipBackgroundColor = ByeBooTheme.colors.whiteAlpha10,
-                    chipTextColor = ByeBooTheme.colors.gray300,
-                    journeyTitleTextColor = ByeBooTheme.colors.gray300,
-                )
+                key(card) {
+                    JourneyCard(
+                        journeyType = card.journeyType,
+                        onJourneyCardClick = onJourneyCompletedCardClick,
+                        chipBackgroundColor = ByeBooTheme.colors.whiteAlpha10,
+                        chipTextColor = ByeBooTheme.colors.gray300,
+                        journeyTitleTextColor = ByeBooTheme.colors.gray300,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #135

## Work Description 📝
- 오프보딩 - 완료한 여정 돌아보기 UI 구현

## Screenshot 📸
<img width="300" height="600" alt="스크린샷 2025-08-14 오전 12 24 03" src="https://github.com/user-attachments/assets/4a5c80ae-5d68-41f4-9809-6885783c38d8" />

<img width="300" height="600" alt="스크린샷 2025-08-14 오전 12 09 51" src="https://github.com/user-attachments/assets/155d9179-796d-42cb-931d-b1298e21a295" />


## Uncompleted Tasks 😅

## PR Point 📌

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 오프보딩 완료 여정 화면을 추가했습니다.
  * 완료한 여정 개수를 표시하고, 완료한 여정 카드 목록을 확인할 수 있습니다.
  * 뒤로가기 아이콘으로 이전 화면으로 이동할 수 있습니다.
  * 완료한 여정이 없을 때 안내 메시지를 표시합니다.

* 리팩터링
  * 여정 카드 목록 렌더링 방식을 개선해 스크롤 및 목록 갱신 시 깜빡임을 줄이고 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->