### PR TITLE
[mod/#148] 마이페이지 수정

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -36,6 +36,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import com.byeboo.app.core.util.openUrl
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.mypage.component.MyPageModal
 
@@ -46,7 +47,7 @@ fun MyPageRoute(
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val localUriHandler = LocalUriHandler.current
+    val context = LocalContext.current
 
     if (uiState.showLogoutModal) {
         MyPageModal(
@@ -72,12 +73,11 @@ fun MyPageRoute(
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { effect ->
             when (effect) {
-                is MyPageSideEffect.OpenUrl -> runCatching {
-                    localUriHandler.openUri(effect.url)
-                }
+                is MyPageSideEffect.OpenUrl -> openUrl(context = context, effect.url)
             }
         }
     }
+
 
     // TODO: 클릭 시 화면 이동 관련 추후에 할 예정
     MyPageScreen(

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,8 +13,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -112,31 +112,30 @@ private fun MyPageScreen(
     onDeleteAccountClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    LazyColumn(
+    Column(
         modifier = modifier
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = 67.dp),
-        contentPadding = PaddingValues(
-            top = 8.dp,
-            bottom = bottomPadding
-        )
+            .padding(top = 67.dp, bottom = bottomPadding)
     ) {
-        stickyHeader {
-            Text(
-                text = "내 정보",
-                style = ByeBooTheme.typography.sub1,
-                color = ByeBooTheme.colors.white,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(ByeBooTheme.colors.black)
-                    .padding(vertical = 16.dp)
-            )
-        }
+        Text(
+            text = "내 정보",
+            style = ByeBooTheme.typography.sub1,
+            color = ByeBooTheme.colors.white,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(ByeBooTheme.colors.black)
+                .padding(vertical = 16.dp)
+        )
 
-        item {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+        ) {
+
             Spacer(modifier = Modifier.height(8.dp))
 
             Row(
@@ -163,9 +162,8 @@ private fun MyPageScreen(
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))
-        }
 
-        item {
+
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -173,9 +171,7 @@ private fun MyPageScreen(
                 thickness = 1.dp,
                 color = ByeBooTheme.colors.whiteAlpha10
             )
-        }
 
-        item {
             Spacer(modifier = Modifier.height(24.dp))
 
             Row(
@@ -221,9 +217,7 @@ private fun MyPageScreen(
             }
 
             Spacer(modifier = Modifier.height(24.dp))
-        }
 
-        item {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Start,
@@ -267,9 +261,7 @@ private fun MyPageScreen(
             }
 
             Spacer(modifier = Modifier.height(24.dp))
-        }
 
-        item {
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -277,9 +269,7 @@ private fun MyPageScreen(
                 thickness = 1.dp,
                 color = ByeBooTheme.colors.whiteAlpha10
             )
-        }
 
-        item {
             Spacer(modifier = Modifier.height(24.dp))
 
             Text(
@@ -305,9 +295,7 @@ private fun MyPageScreen(
                 color = ByeBooTheme.colors.gray50,
                 modifier = Modifier.clickable(onClick = onServiceWithByeBooClick)
             )
-        }
 
-        item {
             Spacer(modifier = Modifier.height(48.dp))
 
             Text(
@@ -333,9 +321,7 @@ private fun MyPageScreen(
                 color = ByeBooTheme.colors.gray50,
                 modifier = Modifier.clickable(onClick = onTermsOfServiceClick)
             )
-        }
 
-        item {
             Spacer(modifier = Modifier.height(48.dp))
 
             Text(
@@ -362,11 +348,7 @@ private fun MyPageScreen(
                 modifier = Modifier.clickable(onClick = onDeleteAccountClick)
             )
 
-            Spacer(modifier = Modifier.height(24.dp))
-        }
-
-        item {
-            Spacer(modifier = Modifier.height(14.dp))
+            Spacer(modifier = Modifier.height(38.dp))
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -35,12 +36,21 @@ fun TermsOfServiceRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is TermsOfServiceSideEffect.OpenUrl -> openUrl(context = context, effect.url)
+            }
+        }
+    }
+
     TermsOfServiceScreen(
         uiState = uiState,
         padding = padding,
-        onAllTermsClick = viewModel::onAllTermsClick,
+        onTermsAllClicked = viewModel::onAllTermsClick,
         onCheckClick = { term -> viewModel.onTermsClick(term) },
-        onLinkClick = { url -> openUrl(context, url) },
+        onTermsLinkClick = { url -> viewModel.onTermsLinkClicked(url) },
+        onNextButton = {},
         modifier = modifier
     )
 
@@ -50,10 +60,11 @@ fun TermsOfServiceRoute(
 private fun TermsOfServiceScreen(
     uiState: TermsOfServiceUiState,
     padding: Dp,
-    onAllTermsClick: () -> Unit,
-    onCheckClick : (TermType) -> Unit,
-    onLinkClick: (String) -> Unit,
-    modifier: Modifier
+    onTermsAllClicked: () -> Unit,
+    onCheckClick: (TermType) -> Unit,
+    onTermsLinkClick: (String?) -> Unit,
+    onNextButton: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
@@ -67,15 +78,16 @@ private fun TermsOfServiceScreen(
         )
 
         Column(
-            modifier = Modifier.padding(horizontal = 24.dp)
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
                 .padding(top = 67.dp, bottom = padding)
                 .fillMaxSize()
         ) {
             TermsHeader()
 
             TermsAllButton(
+                onTermsAllClick = onTermsAllClicked,
                 isChecked = uiState.isAllChecked,
-                onClick = { onAllTermsClick() }
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -88,8 +100,8 @@ private fun TermsOfServiceScreen(
                         title = term.content,
                         hasMoreText = term.hasMoreText,
                         isSelected = uiState.isChecked(term),
-                        onCheckClick = {onCheckClick(term)},
-                        onLinkClick = { term.link?.let { onLinkClick(it) } }
+                        onCheckClick = { onCheckClick(term) },
+                        onLinkClick = { onTermsLinkClick(term.link) }
                     )
                 }
             }
@@ -101,7 +113,7 @@ private fun TermsOfServiceScreen(
                 buttonText = "다음으로",
                 buttonDisableTextColor = ByeBooTheme.colors.gray400,
                 isEnabled = uiState.isAllChecked,
-                onClick = {}
+                onClick = onNextButton
             )
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceState.kt
@@ -15,3 +15,7 @@ data class TermsOfServiceUiState(
 
     fun isChecked(term: TermType): Boolean = term in checkedTerms
 }
+
+sealed interface TermsOfServiceSideEffect {
+    data class OpenUrl(val url: String): TermsOfServiceSideEffect
+}

--- a/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceViewModel.kt
@@ -1,11 +1,15 @@
 package com.byeboo.app.presentation.splash.termsofservice
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -14,7 +18,18 @@ class TermsOfServiceViewModel @Inject constructor() : ViewModel() {
     private val _uiState = MutableStateFlow(TermsOfServiceUiState())
     val uiState: StateFlow<TermsOfServiceUiState> = _uiState.asStateFlow()
 
+    private val _sideEffect = MutableSharedFlow<TermsOfServiceSideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
+
     private val ALL_TERMS: Set<TermType> = TermType.entries.toSet()
+
+    fun onTermsLinkClicked(url: String?) {
+        viewModelScope.launch {
+            url?.let {
+                _sideEffect.emit(TermsOfServiceSideEffect.OpenUrl(url))
+            }
+        }
+    }
 
     fun onAllTermsClick() {
         _uiState.update { state ->

--- a/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceViewModel.kt
@@ -26,7 +26,7 @@ class TermsOfServiceViewModel @Inject constructor() : ViewModel() {
     fun onTermsLinkClicked(url: String?) {
         viewModelScope.launch {
             url?.let {
-                _sideEffect.emit(TermsOfServiceSideEffect.OpenUrl(url))
+                _sideEffect.emit(TermsOfServiceSideEffect.OpenUrl(it))
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/component/TermsAllButton.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/component/TermsAllButton.kt
@@ -24,10 +24,9 @@ import com.byeboo.app.core.util.noRippleClickable
 
 @Composable
 fun TermsAllButton(
-    onClick: (Boolean) -> Unit,
+    onTermsAllClick: () -> Unit,
     modifier: Modifier = Modifier,
-    isChecked: Boolean = false,
-
+    isChecked: Boolean = false
 ) {
     val checkedIcon = if (isChecked) R.drawable.ic_terms_checked else R.drawable.ic_terms_unchecked
     val textColor = if (isChecked) ByeBooTheme.colors.gray50 else ByeBooTheme.colors.gray300
@@ -38,7 +37,7 @@ fun TermsAllButton(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Row(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .background(
                     color = backgroundColor,
@@ -52,7 +51,7 @@ fun TermsAllButton(
                     ) else Modifier
                 )
                 .padding(vertical = 18.dp, horizontal = 24.dp)
-                .noRippleClickable { onClick(!isChecked) },
+                .noRippleClickable(onClick = onTermsAllClick),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(


### PR DESCRIPTION
## Related issue 🛠
- closed #148 

## Work Description 📝
마이 페이지 화면 수정을 하였습니다.
- Uri 호출하는 방법 변경
 - 고정 헤더 관련 수정

추가로 약관화면 uri 호출하는 부분 사이드이펙트 처리 해놨고 버튼도 조금 수정해놨습니다!

## Screenshot 📸
https://github.com/user-attachments/assets/d57f709f-f1ac-4a68-8d86-ed0f076b6c7f


(아래 PR에 있는 영상을 보면 헤더가 움직이는 걸 확인할 수 있습니다)
https://github.com/36-APPJAM-HEARTZ/ByeBoo-ANDROID/pull/140

## Uncompleted Tasks 😅
- N/A

## PR Point 📌
이전에는 LazyColumn으로 코드를 짰었는데 그러면 스크롤 할 때 헤더가 움직이는 현상이 있었습니다.
헤더 움직임을 없애고자 LazyColumn 대신 Column으로 사용해 scroll을 주는 방식으로 변경했습니다.

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 마이페이지 레이아웃을 스티키 헤더 기반에서 단일 스크롤 레이아웃으로 재구성해 스크롤 경험을 단순화했습니다.
* **New Features**
  * 이용약관 화면에 URL 열기용 사이드이펙트 경로와 사이드이펙트 이벤트 방출을 추가했습니다.
* **API 변경**
  * 이용약관 화면과 관련 버튼의 콜백 시그니처를 정리해 호출 흐름을 명확히 했습니다.
* **Style**
  * 상단 헤더 중앙 정렬 및 섹션 간 여백과 하단 공간을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->