### PR TITLE
[feat/#153] 에러 핸들링

### DIFF
--- a/app/src/main/java/com/byeboo/app/core/designsystem/component/snackbar/CustomSnackBar.kt
+++ b/app/src/main/java/com/byeboo/app/core/designsystem/component/snackbar/CustomSnackBar.kt
@@ -1,0 +1,67 @@
+package com.byeboo.app.core.designsystem.component.snackbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.byeboo.app.R
+import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+
+@Composable
+fun CustomSnackBar(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .background(
+                color = ByeBooTheme.colors.blackAlpha80,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_alert),
+            contentDescription = "알림",
+            tint = Color.Unspecified,
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Text(
+            text = message,
+            style = ByeBooTheme.typography.body6,
+            color = ByeBooTheme.colors.gray50
+        )
+    }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CustomSnackBarPreview() {
+    ByeBooTheme {
+        CustomSnackBar(
+            message = "서버에 연결할 수 없습니다. 잠시 후 시도해 주세요.",
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/byeboo/app/core/designsystem/component/snackbar/CustomSnackBar.kt
+++ b/app/src/main/java/com/byeboo/app/core/designsystem/component/snackbar/CustomSnackBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
@@ -28,7 +27,6 @@ fun CustomSnackBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp)
             .background(
                 color = ByeBooTheme.colors.blackAlpha80,
                 shape = RoundedCornerShape(12.dp)
@@ -48,20 +46,6 @@ fun CustomSnackBar(
             text = message,
             style = ByeBooTheme.typography.body6,
             color = ByeBooTheme.colors.gray50
-        )
-    }
-
-}
-
-@Preview(showBackground = true)
-@Composable
-fun CustomSnackBarPreview() {
-    ByeBooTheme {
-        CustomSnackBar(
-            message = "서버에 연결할 수 없습니다. 잠시 후 시도해 주세요.",
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/core/designsystem/event/SnackbarTrigger.kt
+++ b/app/src/main/java/com/byeboo/app/core/designsystem/event/SnackbarTrigger.kt
@@ -1,0 +1,7 @@
+package com.byeboo.app.core.designsystem.event
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalSnackBarTrigger = staticCompositionLocalOf<(String) -> Unit> {
+    error("No SnackBar provided")
+}

--- a/app/src/main/java/com/byeboo/app/core/state/UiState.kt
+++ b/app/src/main/java/com/byeboo/app/core/state/UiState.kt
@@ -1,0 +1,15 @@
+package com.byeboo.app.core.state
+
+sealed interface UiState<out T> {
+    data object Empty : UiState<Nothing>
+
+    data object Loading : UiState<Nothing>
+
+    data class Success<T>(
+        val data: T
+    ) : UiState<T>
+
+    data class Failure(
+        val msg: String
+    ) : UiState<Nothing>
+}

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestStateRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestStateRepositoryImpl.kt
@@ -13,10 +13,12 @@ class QuestStateRepositoryImpl @Inject constructor(
     private val userLocalDataSource: UserLocalDataSource
 ) : QuestStateRepository {
     override suspend fun updateQuestState() {
-        runCatching {
-            questStateDataSource.updateQuestState()
+        val response = questStateDataSource.updateQuestState()
+        if (!response.success) {
+            throw IllegalStateException(response.message)
         }
     }
+
 
     override suspend fun updateUserJourney(journey: String) {
         userLocalDataSource.saveJourney(journey)

--- a/app/src/main/java/com/byeboo/app/data/service/auth/UserService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/auth/UserService.kt
@@ -6,10 +6,10 @@ import com.byeboo.app.data.dto.response.auth.UserInfoResponseDto
 import com.byeboo.app.data.dto.response.auth.UserJourneyResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.POST
+import retrofit2.http.PATCH
 
 interface UserService {
-    @POST("/api/v1/users")
+    @PATCH("/api/v1/users")
     suspend fun updateUserInfo(
         @Body request: UserInfoRequestDto
     ): BaseResponse<UserInfoResponseDto>

--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoScreen.kt
@@ -35,6 +35,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.component.backhandler.ByeBooBackHandler
 import com.byeboo.app.core.designsystem.component.button.ByeBooActivationButton
+import com.byeboo.app.core.designsystem.event.LocalSnackBarTrigger
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.addFocusCleaner
 import com.byeboo.app.core.util.noRippleClickable
@@ -58,6 +59,7 @@ fun UserInfoRoute(
     viewModel: UserInfoViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val showSnackBar = LocalSnackBarTrigger.current
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 3 })
     var previousPage by remember { mutableStateOf(0) }
 
@@ -65,6 +67,9 @@ fun UserInfoRoute(
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 is UserInfoSideEffect.NavigateToLoading -> navigateToLoading()
+                is UserInfoSideEffect.ShowSnackBar -> {
+                    showSnackBar(effect.message)
+                }
             }
         }
     }
@@ -150,7 +155,6 @@ private fun UserInfoScreen(
         ) {
             Spacer(modifier = Modifier.padding(top = screenHeightDp(padding + 27.dp)))
 
-            // 뒤로가기 아이콘
             Box(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoState.kt
@@ -13,4 +13,5 @@ data class UserInfoState(
 )
 sealed interface UserInfoSideEffect {
     data object NavigateToLoading : UserInfoSideEffect
+    data class ShowSnackBar(val message: String) : UserInfoSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoViewModel.kt
@@ -88,6 +88,8 @@ class UserInfoViewModel @Inject constructor(
                     questStateRepository.updateUserJourney(it.toJourneyText())
                 }
                 _sideEffect.emit(UserInfoSideEffect.NavigateToLoading)
+            } else {
+                _sideEffect.emit(UserInfoSideEffect.ShowSnackBar("서버에 연결할 수 없습니다. 잠시 후 시도해 주세요."))
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/home/homeamulet/HomeAmuletScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/homeamulet/HomeAmuletScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
+import com.byeboo.app.core.designsystem.event.LocalSnackBarTrigger
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenHeightDp
@@ -38,20 +39,34 @@ fun HomeAmuletRoute(
     viewModel: HomeAmuletViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val showSnackBar = LocalSnackBarTrigger.current
     var isFlipped by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { effect ->
-            if (effect is HomeAmuletSideEffect.NavigateToHomeOnboarding) {
-                navigateToHomeOnboarding()
+            when (effect) {
+                is HomeAmuletSideEffect.NavigateToHomeOnboarding -> navigateToHomeOnboarding()
+                is HomeAmuletSideEffect.ShowSnackBar -> showSnackBar(effect.message)
             }
+        }
+    }
+
+    LaunchedEffect(uiState.canFlip) {
+        if (uiState.canFlip && !isFlipped) {
+            isFlipped = true
         }
     }
 
     HomeAmuletScreen(
         uiState = uiState,
         isFlipped = isFlipped,
-        onFlip = { isFlipped = true },
+        onFlip = {
+            if (uiState.canFlip) {
+                isFlipped = true
+            } else {
+                viewModel.fetchJourneyFromServer()
+            }
+        },
         onConfirm = viewModel::navigateToHomeOnboarding,
         modifier = modifier
     )

--- a/app/src/main/java/com/byeboo/app/presentation/home/homeamulet/HomeAmuletState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/homeamulet/HomeAmuletState.kt
@@ -4,11 +4,13 @@ import com.byeboo.app.R
 
 data class HomeAmuletState(
     val journey: AmuletType = AmuletType.EMOTION_FACE,
-    val journeyDescription: String = ""
+    val journeyDescription: String = "",
+    val canFlip: Boolean = false
 )
 
 sealed interface HomeAmuletSideEffect {
     data object NavigateToHomeOnboarding : HomeAmuletSideEffect
+    data class ShowSnackBar(val message: String) : HomeAmuletSideEffect
 }
 
 enum class AmuletType(

--- a/app/src/main/java/com/byeboo/app/presentation/home/homeamulet/HomeAmuletViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/homeamulet/HomeAmuletViewModel.kt
@@ -29,35 +29,35 @@ class HomeAmuletViewModel @Inject constructor(
 
     init {
         fetchJourneyFromLocal()
-        fetchJourneyFromServer()
     }
 
     private fun fetchJourneyFromLocal() {
         viewModelScope.launch {
             val localJourney: String? = questStateRepository.getUserJourney()
-
             if (localJourney != null) {
                 val amuletType = AmuletType.from(localJourney)
-
-                _uiState.update {
-                    it.copy(journey = amuletType)
-                }
+                _uiState.update { it.copy(journey = amuletType) }
             }
         }
     }
 
-    private fun fetchJourneyFromServer() {
+    fun fetchJourneyFromServer() {
         viewModelScope.launch {
-            val result = userRepository.getUserJourney()
-            if (result.isSuccess) {
-                val data = result.getOrThrow()
-                _uiState.update {
-                    it.copy(
-                        journey = AmuletType.from(data.journey),
-                        journeyDescription = data.description
+            userRepository.getUserJourney()
+                .onSuccess { data ->
+                    _uiState.update {
+                        it.copy(
+                            journey = AmuletType.from(data.journey),
+                            journeyDescription = data.description,
+                            canFlip = true
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _sideEffect.emit(
+                        HomeAmuletSideEffect.ShowSnackBar("서버에 연결할 수 없습니다. 잠시 후 시도해 주세요.")
                     )
                 }
-            }
         }
     }
 

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
@@ -3,21 +3,30 @@ package com.byeboo.app.presentation.main
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.navOptions
 import com.byeboo.app.core.designsystem.component.backhandler.ByeBooBackHandler
+import com.byeboo.app.core.designsystem.component.snackbar.CustomSnackBar
+import com.byeboo.app.core.designsystem.event.LocalSnackBarTrigger
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.presentation.home.navigation.Home
 import com.byeboo.app.presentation.main.component.MainBottomBar
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -26,9 +35,22 @@ fun MainScreen(
     viewModel: MainViewModel = hiltViewModel()
 ) {
     val scope = rememberCoroutineScope()
+    val snackBarHostState = remember { SnackbarHostState() }
     var isNavigating by remember { mutableStateOf(false) }
     val currentTab = navigator.currentTab
     val showBottomBar = navigator.showBottomBar()
+
+    val onShowSnackBar: (String) -> Unit = { message ->
+        scope.launch {
+            snackBarHostState.currentSnackbarData?.dismiss()
+            val job = launch {
+                snackBarHostState.showSnackbar(message)
+            }
+            delay(3000L)
+            job.cancel()
+        }
+    }
+
 
     if (showBottomBar) {
         if (currentTab == MainNavTab.HOME) {
@@ -37,51 +59,63 @@ fun MainScreen(
             BackHandler { navigator.navigate(MainNavTab.HOME) }
         }
     }
-
-    Scaffold(
-        bottomBar = {
-            MainBottomBar(
-                visible = navigator.showBottomBar(),
-                tabs = MainNavTab.entries.toImmutableList(),
-                currentTab = currentTab,
-                onTabSelected = { selectedTab ->
-                    if (isNavigating || selectedTab == currentTab) return@MainBottomBar
-                    scope.launch {
-                        isNavigating = true
-                        try {
-                            val navOptions = navOptions {
-                                popUpTo(Home) {
-                                    saveState = true
-                                    inclusive = false
+    CompositionLocalProvider(
+        LocalSnackBarTrigger provides onShowSnackBar
+    ) {
+        Scaffold(
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = snackBarHostState,
+                    modifier = Modifier
+                        .padding(bottom = screenHeightDp(68.dp))
+                ) { snackBar ->
+                    CustomSnackBar(message = snackBar.visuals.message)
+                }
+            },
+            bottomBar = {
+                MainBottomBar(
+                    visible = navigator.showBottomBar(),
+                    tabs = MainNavTab.entries.toImmutableList(),
+                    currentTab = currentTab,
+                    onTabSelected = { selectedTab ->
+                        if (isNavigating || selectedTab == currentTab) return@MainBottomBar
+                        scope.launch {
+                            isNavigating = true
+                            try {
+                                val navOptions = navOptions {
+                                    popUpTo(Home) {
+                                        saveState = true
+                                        inclusive = false
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                            if (selectedTab == MainNavTab.QUEST) {
-                                val isStarted = viewModel.isQuestStarted()
-                                if (isStarted) {
-                                    navigator.navigateToQuest(navOptions)
+                                if (selectedTab == MainNavTab.QUEST) {
+                                    val isStarted = viewModel.isQuestStarted()
+                                    if (isStarted) {
+                                        navigator.navigateToQuest(navOptions)
+                                    } else {
+                                        navigator.navigateToQuestStart(navOptions)
+                                    }
                                 } else {
-                                    navigator.navigateToQuestStart(navOptions)
+                                    navigator.navigate(selectedTab)
                                 }
-                            } else {
-                                navigator.navigate(selectedTab)
+                            } finally {
+                                isNavigating = false
                             }
-                        } finally {
-                            isNavigating = false
                         }
                     }
-                }
-            )
-        },
-        modifier = Modifier
-            .fillMaxSize()
-            .background(ByeBooTheme.colors.black)
-    ) {
-        MainNavHost(
-            navigator = navigator,
-            padding = it.calculateBottomPadding(),
+                )
+            },
             modifier = Modifier
-        )
+                .fillMaxSize()
+                .background(ByeBooTheme.colors.black)
+        ) {
+            MainNavHost(
+                navigator = navigator,
+                padding = it.calculateBottomPadding(),
+                modifier = Modifier
+            )
+        }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
@@ -23,6 +23,7 @@ import com.byeboo.app.core.designsystem.component.snackbar.CustomSnackBar
 import com.byeboo.app.core.designsystem.event.LocalSnackBarTrigger
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.screenHeightDp
+import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.home.navigation.Home
 import com.byeboo.app.presentation.main.component.MainBottomBar
 import kotlinx.collections.immutable.toImmutableList
@@ -67,6 +68,7 @@ fun MainScreen(
                 SnackbarHost(
                     hostState = snackBarHostState,
                     modifier = Modifier
+                        .padding(horizontal = screenWidthDp(24.dp))
                         .padding(bottom = screenHeightDp(68.dp))
                 ) { snackBar ->
                     CustomSnackBar(message = snackBar.visuals.message)

--- a/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
@@ -24,6 +24,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.component.button.ByeBooButton
+import com.byeboo.app.core.designsystem.event.LocalSnackBarTrigger
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenHeightDp
@@ -39,12 +40,14 @@ fun QuestStartRoute(
     viewModel: QuestStartViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val showSnackBar = LocalSnackBarTrigger.current
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 is QuestStartSideEffect.NavigateToQuest -> navigateToQuest()
                 is QuestStartSideEffect.NavigateToHome -> navigateToHome()
+                is QuestStartSideEffect.ShowSnackBar -> showSnackBar(effect.message)
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartState.kt
@@ -11,4 +11,5 @@ data class QuestStartState(
 sealed interface QuestStartSideEffect {
     data object NavigateToQuest : QuestStartSideEffect
     data object NavigateToHome : QuestStartSideEffect
+    data class ShowSnackBar(val message: String) : QuestStartSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartViewModel.kt
@@ -43,11 +43,19 @@ class QuestStartViewModel @Inject constructor(
 
     fun onStartClicked() {
         viewModelScope.launch {
-            questStateRepository.updateQuestState()
-            questStateRepository.setQuestStarted(true)
-            _sideEffect.emit(QuestStartSideEffect.NavigateToQuest)
+            runCatching {
+                questStateRepository.updateQuestState()
+                questStateRepository.setQuestStarted(true)
+            }.onSuccess {
+                _sideEffect.emit(QuestStartSideEffect.NavigateToQuest)
+            }.onFailure { e ->
+                _sideEffect.emit(
+                    QuestStartSideEffect.ShowSnackBar("서버에 연결할 수 없습니다. 잠시 후 시도해 주세요.")
+                )
+            }
         }
     }
+
 
     fun onBackClicked() {
         viewModelScope.launch {

--- a/app/src/main/res/drawable/ic_alert.xml
+++ b/app/src/main/res/drawable/ic_alert.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8,2C11.314,2 14,4.686 14,8C14,11.314 11.314,14 8,14C4.686,14 2,11.314 2,8C2,4.686 4.686,2 8,2Z"
+      android:fillColor="#FF3B3E"/>
+  <path
+      android:pathData="M8.665,4.333L8.51,9.605H7.517L7.332,4.333H8.665ZM8.023,10.49C8.373,10.49 8.617,10.726 8.617,11.074C8.617,11.422 8.373,11.667 8.023,11.667C7.663,11.667 7.41,11.422 7.41,11.074C7.41,10.726 7.663,10.49 8.023,10.49Z"
+      android:fillColor="#FEFEFE"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #153

## Work Description 📝
- 에러 핸들링 관련 스낵바를 추가했습니다

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/cd05636f-3a35-42e9-bb54-817a5aa75aba" width="360" />


## Uncompleted Tasks 😅
- [ ] 퀘스트 화면 에러 핸들링

## PR Point 📌
일단 임시로 몇 개의 화면만 에러 핸들링을 추가했습니다. 아직 여러번 스낵 바를 띄웠을 때 문제점 같은 것은 고려하지 않았습니다. 디자인 적으로 놓친 부분 있는지 봐주시면 감사하겠습니다~
부적 화면 같은 경우 부적을 뒤집을 때 api를 호출하도록 로직을 수정했습니다.
추가적으로 퀘스트나 홈 화면 같이 처음 상태를 fetch하는 화면 같은 경우는 UiState로 로딩 여부를 관리해 볼 생각이라 아직 추가하진 않았습니다!
## 트러블 슈팅 💥
퀘스트 시작 화면 에러 핸들링에서 문제가 조금 있는거 같은데 이 부분 빠르게 수정해볼게요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 앱 전역 커스텀 스낵바 도입: 아이콘 포함한 스타일로 홈·사용자정보·퀘스트 시작 등에서 메시지 표시.
  - 홈 부적 화면 자동 플립: 서버 동기화 성공 시 카드 자동 뒤집기.

- 리팩터링
  - 메인 화면 네비게이션 안정성 향상(중복 이동 방지, 상태 복원) 및 스낵바 표시/해제 타이밍 로직 추가.
  - 퀘스트 시작·사용자 정보 흐름에서 실패 시 스낵바로 오류 안내.

- 잡무
  - 사용자 정보 업데이트 요청을 PATCH로 변경.
  - 스낵바용 경고 아이콘 리소스 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->