### PR TITLE
[feat/#142] 상태에 따른 홈 화면 변경

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/dto/response/quest/QuestCountResponseDto.kt
+++ b/app/src/main/java/com/byeboo/app/data/dto/response/quest/QuestCountResponseDto.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.Serializable
 data class QuestCountResponseDto(
     @SerialName("todayComplete")
     val todayComplete: Boolean,
+    @SerialName("userCurrentStatus")
+    val userCurrentStatus: String,
     @SerialName("count")
     val count: Long
 )

--- a/app/src/main/java/com/byeboo/app/data/mapper/quest/QuestStateMapper.kt
+++ b/app/src/main/java/com/byeboo/app/data/mapper/quest/QuestStateMapper.kt
@@ -8,6 +8,7 @@ import com.byeboo.app.domain.model.quest.QuestStateModel
 fun QuestCountResponseDto.toDomain(): QuestStateModel {
     return QuestStateModel(
         todayComplete = this.todayComplete,
+        userCurrentStatus = this.userCurrentStatus,
         count = this.count.toInt()
     )
 }

--- a/app/src/main/java/com/byeboo/app/domain/model/home/HomeStatus.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/home/HomeStatus.kt
@@ -1,0 +1,18 @@
+package com.byeboo.app.domain.model.home
+
+enum class HomeStatus {
+    INITIAL_START,
+    TODAY_INCOMPLETE,
+    TODAY_COMPLETE,
+    JOURNEY_COMPLETE;
+
+    companion object {
+        fun from(status: String?): HomeStatus = when (status) {
+            "INITIAL_START_STATUS" -> INITIAL_START
+            "TODAY_NOT_COMPLETED_STATUS" -> TODAY_INCOMPLETE
+            "TODAY_COMPLETED_STATUS" -> TODAY_COMPLETE
+            "JOURNEY_COMPLETED_STATUS" -> JOURNEY_COMPLETE
+            else -> INITIAL_START
+        }
+    }
+}

--- a/app/src/main/java/com/byeboo/app/domain/model/quest/QuestStateModel.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/quest/QuestStateModel.kt
@@ -2,6 +2,7 @@ package com.byeboo.app.domain.model.quest
 
 data class QuestStateModel(
     val todayComplete: Boolean,
+    val userCurrentStatus: String,
     val count: Int
 )
 

--- a/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
@@ -43,6 +43,7 @@ import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenHeightDp
+import com.byeboo.app.domain.model.home.HomeStatus
 import com.byeboo.app.presentation.home.component.HomeProgressCard
 import com.byeboo.app.presentation.home.component.HomeQuestCard
 import kotlinx.coroutines.delay
@@ -91,8 +92,8 @@ private fun HomeScreen(
 
     var showBubble by remember { mutableStateOf(false) }
 
-    LaunchedEffect(uiState.isQuestStarted, uiState.hasSeenAboutHelp) {
-        if (uiState.isQuestStarted == false && !uiState.hasSeenAboutHelp) {
+    LaunchedEffect(uiState.status, uiState.hasSeenAboutHelp) {
+        if (uiState.status == HomeStatus.INITIAL_START && !uiState.hasSeenAboutHelp) {
             delay(300)
             showBubble = true
         } else {
@@ -119,53 +120,79 @@ private fun HomeScreen(
                 .padding(horizontal = screenHeightDp(24.dp))
                 .padding(top = screenHeightDp(67.dp))
         ) {
-            if (uiState.isQuestStarted == true) {
-                HomeQuestCard(
-                    title = "오늘의 퀘스트 하러가기",
-                    subtitle = "퀘스트를 하고나면 한층 더 성장할 거에요.",
-                    onClick = onClickQuest
-                )
-                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-                HomeProgressCard(
-                    title = "${uiState.nickname}님의 ${uiState.journey} 여정",
-                    currentStep = uiState.currentStep,
-                    totalSteps = uiState.totalSteps
-                )
-            } else {
-                HomeQuestCard(
-                    title = "${uiState.journey} 여정 시작하기",
-                    subtitle = "제가 옆에서 함께할게요!",
-                    onClick = onClickQuestStart
-                )
-                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_home_question),
-                    contentDescription = null,
-                    tint = Color.Unspecified,
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .noRippleClickable {
-                            onHelpIconClick()
-                            showBubble = false
-                        }
-                )
-                Spacer(modifier = Modifier.height(screenHeightDp(4.dp)))
-                AnimatedVisibility(
-                    visible = showBubble && !uiState.hasSeenAboutHelp,
-                    enter = fadeIn(animationSpec = tween(220)) +
-                            scaleIn(
-                                initialScale = 0.96f,
-                                animationSpec = tween(300, easing = FastOutSlowInEasing)
-                            ),
-                    modifier = Modifier.align(Alignment.End)
-                ) {
-                    Image(
-                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_home_about_bori),
-                        contentDescription = "보리 소개 말풍선"
+            when (uiState.status) {
+                HomeStatus.INITIAL_START -> {
+                    HomeQuestCard(
+                        title = "${uiState.journey} 여정 시작하기",
+                        subtitle = "제가 옆에서 함께할게요!",
+                        onClick = onClickQuestStart
+                    )
+                    Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_home_question),
+                        contentDescription = null,
+                        tint = Color.Unspecified,
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .noRippleClickable {
+                                onHelpIconClick()
+                                showBubble = false
+                            }
+                    )
+                    Spacer(modifier = Modifier.height(screenHeightDp(4.dp)))
+                    AnimatedVisibility(
+                        visible = showBubble && !uiState.hasSeenAboutHelp,
+                        enter = fadeIn(animationSpec = tween(220)) +
+                                scaleIn(
+                                    initialScale = 0.96f,
+                                    animationSpec = tween(300, easing = FastOutSlowInEasing)
+                                ),
+                        modifier = Modifier.align(Alignment.End)
+                    ) {
+                        Image(
+                            imageVector = ImageVector.vectorResource(id = R.drawable.ic_home_about_bori),
+                            contentDescription = "보리 소개 말풍선"
+                        )
+                    }
+                }
+                HomeStatus.TODAY_INCOMPLETE -> {
+                    HomeQuestCard(
+                        title = "오늘의 퀘스트 하러가기",
+                        subtitle = "퀘스트를 하고나면 한층 더 성장할 거에요.",
+                        onClick = onClickQuest
+                    )
+                    Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+                    HomeProgressCard(
+                        title = "${uiState.nickname}님의 ${uiState.journey} 여정",
+                        currentStep = uiState.currentStep,
+                        totalSteps = uiState.totalSteps
                     )
                 }
 
+                HomeStatus.TODAY_COMPLETE -> {
+                    HomeQuestCard(
+                        title = "오늘의 퀘스트 완료!",
+                        subtitle = "잘하셨어요! 내일 또 만나요.",
+                        onClick = onClickQuest
+                    )
+                    Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+                    HomeProgressCard(
+                        title = "${uiState.nickname}님의 ${uiState.journey} 여정",
+                        currentStep = uiState.currentStep,
+                        totalSteps = uiState.totalSteps
+                    )
+                }
+
+                HomeStatus.JOURNEY_COMPLETE -> {
+                    HomeQuestCard(
+                        title = "새로운 이별 극복 여정 시작하기",
+                        subtitle = "다음 여정도, 제가 곁에서 함께할게요.",
+                        /// TODO: 새로운 여정 화면 이동
+                        onClick = {}
+                    )
+                }
             }
+
 
             Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
 
@@ -186,29 +213,23 @@ private fun HomeScreen(
                     .padding(horizontal = screenHeightDp(24.dp))
             )
 
-            if (uiState.isQuestStarted == true) {
-                Text(
-                    text = "${uiState.nickname}님만의 속도로 나아가봐요",
-                    style = ByeBooTheme.typography.body2,
-                    color = ByeBooTheme.colors.primary50,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .padding(top = 13.dp)
-                )
-            } else {
-                Text(
-                    text = "${uiState.nickname}님의 이별 극복을 도와드릴게요",
-                    style = ByeBooTheme.typography.body2,
-                    color = ByeBooTheme.colors.primary50,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .padding(top = 13.dp)
-                )
+            val bottomBubbleText = when (uiState.status) {
+                HomeStatus.INITIAL_START -> "${uiState.nickname}님의 이별 극복을 도와드릴게요"
+                HomeStatus.TODAY_INCOMPLETE -> "${uiState.nickname}님만의 속도로 나아가봐요"
+                HomeStatus.TODAY_COMPLETE -> "오늘도 잘 이겨내셨어요!"
+                HomeStatus.JOURNEY_COMPLETE -> "저는 언제 여기에 있어요!"
             }
+
+            Text(
+                text = bottomBubbleText,
+                style = ByeBooTheme.typography.body2,
+                color = ByeBooTheme.colors.primary50,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 13.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
@@ -217,7 +217,7 @@ private fun HomeScreen(
                 HomeStatus.INITIAL_START -> "${uiState.nickname}님의 이별 극복을 도와드릴게요"
                 HomeStatus.TODAY_INCOMPLETE -> "${uiState.nickname}님만의 속도로 나아가봐요"
                 HomeStatus.TODAY_COMPLETE -> "오늘도 잘 이겨내셨어요!"
-                HomeStatus.JOURNEY_COMPLETE -> "저는 언제 여기에 있어요!"
+                HomeStatus.JOURNEY_COMPLETE -> "저는 언제나 여기에 있어요!"
             }
 
             Text(

--- a/app/src/main/java/com/byeboo/app/presentation/home/HomeUiState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/HomeUiState.kt
@@ -1,7 +1,9 @@
 package com.byeboo.app.presentation.home
 
+import com.byeboo.app.domain.model.home.HomeStatus
+
 data class HomeUiState(
-    val isQuestStarted: Boolean? = false,
+    val status: HomeStatus = HomeStatus.INITIAL_START,
     val journey: String = "",
     val currentStep: Int = 0,
     val totalSteps: Int = 30,

--- a/app/src/main/java/com/byeboo/app/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/HomeViewModel.kt
@@ -56,16 +56,22 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun onClickQuest() = viewModelScope.launch {
-        _sideEffect.emit(HomeSideEffect.NavigateToQuest)
+    fun onClickQuest() {
+        viewModelScope.launch {
+            _sideEffect.emit(HomeSideEffect.NavigateToQuest)
+        }
     }
 
-    fun onClickQuestStart() = viewModelScope.launch {
-        _sideEffect.emit(HomeSideEffect.NavigateToQuestStart)
+    fun onClickQuestStart() {
+        viewModelScope.launch {
+            _sideEffect.emit(HomeSideEffect.NavigateToQuestStart)
+        }
     }
 
-    fun onHelpIconClicked() = viewModelScope.launch {
-        userRepository.setHasSeenAboutHelp(true)
-        _uiState.update { it.copy(hasSeenAboutHelp = true) }
+    fun onHelpIconClicked() {
+        viewModelScope.launch {
+            userRepository.setHasSeenAboutHelp(true)
+            _uiState.update { it.copy(hasSeenAboutHelp = true) }
+        }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.byeboo.app.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.byeboo.app.domain.model.home.HomeStatus
 import com.byeboo.app.domain.repository.auth.UserRepository
 import com.byeboo.app.domain.repository.quest.QuestStateRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,6 +11,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -21,35 +23,32 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
-    val uiState: StateFlow<HomeUiState> = _uiState
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     private val _sideEffect = MutableSharedFlow<HomeSideEffect>()
     val sideEffect = _sideEffect.asSharedFlow()
 
     init {
         viewModelScope.launch {
-
             val nickname = userRepository.getNickname().firstOrNull() ?: "하츠핑"
-
-            val isStarted = questStateRepository.isQuestStarted()
             val journey = questStateRepository.getUserJourney() ?: "감정 직면"
-
             val hasSeenAboutHelp = userRepository.hasSeenAboutHelp()
 
-            var currentStep: Int? = null
-            if (isStarted) {
-                questStateRepository.getQuestCount()
-                    .onSuccess { model ->
-                        currentStep = model.count
-                    }
-            }
+            var status = HomeStatus.INITIAL_START
+            var currentStep = 0
+
+            questStateRepository.getQuestCount()
+                .onSuccess { model ->
+                    status = HomeStatus.from(model.userCurrentStatus)
+                    currentStep = model.count
+                }
 
             _uiState.update {
                 it.copy(
                     nickname = nickname,
-                    isQuestStarted = isStarted,
                     journey = journey,
-                    currentStep = currentStep ?: 0,
+                    status = status,
+                    currentStep = currentStep,
                     totalSteps = 30,
                     hasSeenAboutHelp = hasSeenAboutHelp
                 )
@@ -57,22 +56,16 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun onClickQuest() {
-        viewModelScope.launch {
-            _sideEffect.emit(HomeSideEffect.NavigateToQuest)
-        }
+    fun onClickQuest() = viewModelScope.launch {
+        _sideEffect.emit(HomeSideEffect.NavigateToQuest)
     }
 
-    fun onClickQuestStart() {
-        viewModelScope.launch {
-            _sideEffect.emit(HomeSideEffect.NavigateToQuestStart)
-        }
+    fun onClickQuestStart() = viewModelScope.launch {
+        _sideEffect.emit(HomeSideEffect.NavigateToQuestStart)
     }
 
-    fun onHelpIconClicked() {
-        viewModelScope.launch {
-            userRepository.setHasSeenAboutHelp(true)
-            _uiState.update { it.copy(hasSeenAboutHelp = true) }
-        }
+    fun onHelpIconClicked() = viewModelScope.launch {
+        userRepository.setHasSeenAboutHelp(true)
+        _uiState.update { it.copy(hasSeenAboutHelp = true) }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #142

## Work Description 📝
- api 응답값에 따른 홈 화면 변경처리했습니다

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] 
## PR Point 📌
퀘스트 시작 여부에 따라 분기처리하던 화면을 서버 응답값에 따라 분기처리하는 방법으로 변경했습니다.
아직 상태에 따른 화면 이동은 구현 하지 않았습니다.
소희가 api 다붙이면 테스트 해볼게요!
아직 JOURNEY_COMPLETE 상태일 때 테스트를 안해봤는데 나중에 오류생기면 이슈파서 수정하겠습니다!
## 트러블 슈팅 💥

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 홈 화면이 상태 기반으로 동작합니다: INITIAL_START, TODAY_INCOMPLETE, TODAY_COMPLETE, JOURNEY_COMPLETE에 따라 서로 다른 카드와 메시지를 표시합니다.
  * 여정 완료 시 “새 여정 시작” 카드 추가 및 초기 시작 시 안내 버블·도움말 아이콘 표시.
  * 퀘스트 상태가 서버 응답에서 직접 반영되어 UI에 노출됩니다.
  * UI 상태에 별칭(nickname)과 도움말 확인 여부(hasSeenAboutHelp) 추가.

* Refactor
  * 단일 불리언에서 명확한 상태 모델로 전환해 화면 흐름과 일관성 개선.
  * UI 상태가 읽기 전용 StateFlow로 노출되도록 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->