### PR TITLE
[feat/#158] 프로필 수정 화면 키보드 애니메이션 설정

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/component/NicknameTextField.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/component/NicknameTextField.kt
@@ -17,8 +17,10 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -28,6 +30,8 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.byeboo.app.R
@@ -62,6 +66,12 @@ fun NicknameTextField(
     val validColor =
         if (focusState.value) ByeBooTheme.colors.gray400 else ByeBooTheme.colors.primary300
 
+    var textFieldValue by remember(value) {
+        mutableStateOf(
+            TextFieldValue(value, selection = TextRange(value.length))
+        )
+    }
+
     Column(modifier = modifier.padding(vertical = screenHeightDp(8.dp))) {
         Box(
             modifier = Modifier
@@ -73,11 +83,23 @@ fun NicknameTextField(
                 .padding(horizontal = screenWidthDp(24.dp), vertical = screenHeightDp(18.dp))
         ) {
             BasicTextField(
-                value = value,
-                onValueChange = onValueChange,
+                value = textFieldValue,
+                onValueChange = { newValue ->
+                    textFieldValue = newValue
+                    if (newValue.text != value) {
+                        onValueChange(newValue.text)
+                    }
+                },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .onFocusChanged { focusState.value = it.isFocused },
+                    .onFocusChanged { focus ->
+                        focusState.value = focus.isFocused
+                        if (focus.isFocused) {
+                            textFieldValue = textFieldValue.copy(
+                                selection = TextRange(textFieldValue.text.length)
+                            )
+                        }
+                    },
                 textStyle = ByeBooTheme.typography.body3.copy(color = ByeBooTheme.colors.white),
                 singleLine = true,
                 cursorBrush = SolidColor(ByeBooTheme.colors.white),
@@ -98,7 +120,7 @@ fun NicknameTextField(
                             modifier = Modifier.weight(1f),
                             contentAlignment = Alignment.CenterStart
                         ) {
-                            if (value.isEmpty()) {
+                            if (textFieldValue.text.isEmpty()) {
                                 Text(
                                     text = "닉네임을 입력해주세요",
                                     style = ByeBooTheme.typography.body3,
@@ -111,14 +133,17 @@ fun NicknameTextField(
                 }
             )
 
-            if (value.isNotEmpty() && focusState.value) {
+            if (textFieldValue.text.isNotEmpty() && focusState.value) {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_delete),
                     contentDescription = "Clear text",
                     tint = Color.Unspecified,
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
-                        .noRippleClickable(onClearClick)
+                        .noRippleClickable{
+                            textFieldValue = TextFieldValue("", selection = TextRange(0))
+                            onClearClick()
+                        }
                 )
             }
         }
@@ -138,7 +163,7 @@ fun NicknameTextField(
                             modifier = Modifier.weight(1f)
                         )
                         Text(
-                            text = "${value.length}/5",
+                            text = "${textFieldValue.text.length}/5",
                             style = ByeBooTheme.typography.cap2,
                             color = validColor
                         )
@@ -165,11 +190,11 @@ fun NicknameTextField(
                         style = ByeBooTheme.typography.cap2,
                         color = ByeBooTheme.colors.error300,
                         modifier = Modifier
-                            .padding(start= 3.dp)
+                            .padding(start = 3.dp)
                             .weight(1f)
                     )
                     Text(
-                        text = "${value.length}/5",
+                        text = "${textFieldValue.text.length}/5",
                         style = ByeBooTheme.typography.cap2,
                         color = ByeBooTheme.colors.error300
                     )
@@ -198,7 +223,7 @@ fun NicknameTextField(
                             .weight(1f)
                     )
                     Text(
-                        text = "${value.length}/5",
+                        text = "${textFieldValue.text.length}/5",
                         style = ByeBooTheme.typography.cap2,
                         color = ByeBooTheme.colors.gray400
                     )

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
@@ -15,7 +15,6 @@ import com.byeboo.app.presentation.auth.navigation.navigateToUserInfo
 import com.byeboo.app.presentation.home.navigation.navigateToHome
 import com.byeboo.app.presentation.home.navigation.navigateToHomeAmulet
 import com.byeboo.app.presentation.home.navigation.navigateToHomeOnboarding
-import com.byeboo.app.presentation.mypage.navigation.MyPage
 import com.byeboo.app.presentation.mypage.navigation.navigateToEditProfile
 import com.byeboo.app.presentation.mypage.navigation.navigateToMyPage
 import com.byeboo.app.presentation.quest.behavior.navigation.navigateToQuestBehavior

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
@@ -1,7 +1,6 @@
 package com.byeboo.app.presentation.mypage.editprofile
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,7 +13,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
@@ -29,30 +31,37 @@ import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.domain.model.auth.NicknameValidationResult
 import com.byeboo.app.presentation.auth.userinfo.component.NicknameTextField
 import com.byeboo.app.presentation.auth.userinfo.model.toValidationState
+import kotlinx.coroutines.delay
 
 @Composable
 fun EditProfileRoute(
     navigateToMyPage: () -> Unit,
     bottomPadding: Dp,
     viewModel: EditProfileViewModel = hiltViewModel()
-){
-
+) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val focusRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { effect ->
-           when(effect) {
-               is EditProfileSideEffect.NavigateToMyPage -> navigateToMyPage()
-           }
+            when (effect) {
+                is EditProfileSideEffect.NavigateToMyPage -> navigateToMyPage()
+            }
         }
+    }
+
+    LaunchedEffect(Unit) {
+        delay(100)
+        focusRequester.requestFocus()
     }
 
     EditProfileScreen(
         uiState = uiState,
         bottomPadding = bottomPadding,
-        onNicknameChange= viewModel::updateNickname,
-        onClearClick = { viewModel.updateNickname("") },
         onBackClick = viewModel::onBackClicked,
+        onNicknameChange = viewModel::updateNickname,
+        onClearClick = { viewModel.updateNickname("") },
+        focusRequester = focusRequester,
         onCompleteClick = viewModel::finishEditProfile
     )
 }
@@ -61,12 +70,13 @@ fun EditProfileRoute(
 private fun EditProfileScreen(
     uiState: EditProfileState,
     bottomPadding: Dp,
+    onBackClick: () -> Unit,
     onNicknameChange: (String) -> Unit,
     onClearClick: () -> Unit,
-    onBackClick: () -> Unit,
+    focusRequester: FocusRequester,
     onCompleteClick: () -> Unit,
     modifier: Modifier = Modifier
-){
+) {
     val isNicknameValid = uiState.nicknameValidation == NicknameValidationResult.Valid
     val showValidMessage = !uiState.isInitial
 
@@ -115,7 +125,8 @@ private fun EditProfileScreen(
             validationState = uiState.nicknameValidation.toValidationState(),
             onValueChange = onNicknameChange,
             onClearClick = onClearClick,
-            showValidMessage = showValidMessage
+            showValidMessage = showValidMessage,
+            modifier = Modifier.focusRequester(focusRequester)
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -126,9 +137,6 @@ private fun EditProfileScreen(
             buttonDisableTextColor = ByeBooTheme.colors.gray300,
             isEnabled = isNicknameValid,
             onClick = onCompleteClick
-
         )
     }
 }
-
-


### PR DESCRIPTION
## Related issue 🛠
- closed #158

## Work Description 📝
- 프로필 수정 화면 진입 시 키보드가 자동으로 올라오도록 구현하였습니다.

## Screenshot 📸
https://github.com/user-attachments/assets/d32651df-1ac8-4886-b9a8-bf2f0cb01400

## Uncompleted Tasks 😅
- N/A

## PR Point 📌
이거 하면서 보니 `TextFieldValue`라는 타입도 있더라고요!
시간 되실 때 한 번 검색해 보시면 좋을 것 같아요~!!

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 프로필 수정 화면에서 닉네임 입력창이 자동 포커스됩니다.

- 버그 수정
  - 닉네임 입력 시 커서가 끝으로 이동하여 자연스럽게 입력됩니다.
  - 플레이스홀더와 글자 수 표시가 실제 입력 내용과 정확히 동기화됩니다.
  - 지우기 동작 시 입력값이 정확히 초기화됩니다.
  - 여백 조정으로 입력 영역 시각적 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->