### PR TITLE
[feat/#165] 로컬에 닉네임, 여정 상태 정보 저장 

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/datasource/local/UserLocalDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/local/UserLocalDataSource.kt
@@ -18,4 +18,5 @@ interface UserLocalDataSource {
     suspend fun setHasSeenAboutHelp(seen: Boolean)
     suspend fun hasSeenAboutHelp(): Boolean
     suspend fun clear()
+    suspend fun saveJourneyStatus(journeyStatus: String)
 }

--- a/app/src/main/java/com/byeboo/app/data/datasource/local/UserLocalDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/local/UserLocalDataSource.kt
@@ -15,8 +15,9 @@ interface UserLocalDataSource {
     suspend fun isQuestStarted(): Boolean
     suspend fun saveJourney(journey: String)
     suspend fun getJourney(): String?
+    suspend fun saveJourneyStatus(journeyStatus: String)
+    suspend fun getJourneyStatus(): String?
     suspend fun setHasSeenAboutHelp(seen: Boolean)
     suspend fun hasSeenAboutHelp(): Boolean
     suspend fun clear()
-    suspend fun saveJourneyStatus(journeyStatus: String)
 }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/UserLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/UserLocalDataSourceImpl.kt
@@ -84,6 +84,14 @@ class UserLocalDataSourceImpl @Inject constructor(
         return dataStore.data.first()[JOURNEY]
     }
 
+    override suspend fun saveJourneyStatus(journeyStatus: String) {
+        dataStore.edit { it[JOURNEY_STATUS] = journeyStatus }
+    }
+
+    override suspend fun getJourneyStatus(): String? {
+        return dataStore.data.first()[JOURNEY_STATUS]
+    }
+
     override suspend fun setHasSeenAboutHelp(seen: Boolean) {
         dataStore.edit { preferences ->
             preferences[HAS_SEEN_ABOUT_HELP] = seen
@@ -103,9 +111,6 @@ class UserLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun saveJourneyStatus(journeyStatus: String) {
-        dataStore.edit { it[JOURNEY_STATUS] = journeyStatus }
-    }
 
     companion object {
         private val IS_LOGGED_IN = booleanPreferencesKey("IS_LOGGED_IN")

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/UserLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/UserLocalDataSourceImpl.kt
@@ -103,6 +103,10 @@ class UserLocalDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun saveJourneyStatus(journeyStatus: String) {
+        dataStore.edit { it[JOURNEY_STATUS] = journeyStatus }
+    }
+
     companion object {
         private val IS_LOGGED_IN = booleanPreferencesKey("IS_LOGGED_IN")
         private val NICKNAME = stringPreferencesKey("NICKNAME")
@@ -110,5 +114,6 @@ class UserLocalDataSourceImpl @Inject constructor(
         private val IS_QUEST_STARTED = booleanPreferencesKey("IS_QUEST_STARTED")
         private val JOURNEY = stringPreferencesKey("JOURNEY")
         private val HAS_SEEN_ABOUT_HELP = booleanPreferencesKey("HAS_SEEN_ABOUT_HELP")
+        private val JOURNEY_STATUS = stringPreferencesKey("JOURNEY_STATUS")
     }
 }

--- a/app/src/main/java/com/byeboo/app/data/dto/response/auth/KakaoLoginResponseDto.kt
+++ b/app/src/main/java/com/byeboo/app/data/dto/response/auth/KakaoLoginResponseDto.kt
@@ -11,4 +11,10 @@ data class KakaoLoginResponseDto(
     val refreshToken: String,
     @SerialName("isRegistered")
     val isRegistered: Boolean,
+    @SerialName("name")
+    val name: String?,
+    @SerialName("journey")
+    val journey: String?,
+    @SerialName("journeyStatus")
+    val journeyStatus: String?
 )

--- a/app/src/main/java/com/byeboo/app/data/mapper/auth/AuthMapper.kt
+++ b/app/src/main/java/com/byeboo/app/data/mapper/auth/AuthMapper.kt
@@ -4,11 +4,31 @@ import com.byeboo.app.core.model.auth.TokenEntity
 import com.byeboo.app.data.dto.response.auth.KakaoLoginResponseDto
 import com.byeboo.app.data.dto.response.auth.TokenReissueResponseDto
 import com.byeboo.app.domain.model.auth.AuthResult
+import com.byeboo.app.domain.model.auth.JourneyStatusType
+import com.byeboo.app.domain.model.auth.JourneyType
 
 fun KakaoLoginResponseDto.toDomain(): AuthResult = AuthResult(
     tokens = TokenEntity(accessToken = accessToken, refreshToken = refreshToken),
-    isRegistered = isRegistered
+    isRegistered = isRegistered,
+    name = name,
+    journey = journey.toJourneyType(),
+    journeyStatus = journeyStatus.toJourneyStatus()
 )
+
+internal fun String?.toJourneyType(): JourneyType = when(this) {
+    "FACE_EMOTION" -> JourneyType.FACE_EMOTION
+    "PROCESS_EMOTION" -> JourneyType.PROCESS_EMOTION
+    null -> JourneyType.UNKNOWN
+    else -> JourneyType.UNKNOWN
+}
+
+internal fun String?.toJourneyStatus(): JourneyStatusType = when (this) {
+    "BEFORE_START" -> JourneyStatusType.BEFORE_START
+    "IN_PROGRESS"  -> JourneyStatusType.IN_PROGRESS
+    "COMPLETED"    -> JourneyStatusType.COMPLETED
+    null -> JourneyStatusType.UNKNOWN
+    else -> JourneyStatusType.UNKNOWN
+}
 
 fun TokenReissueResponseDto.toDomain(): TokenEntity = TokenEntity(
     accessToken = this.accessToken,

--- a/app/src/main/java/com/byeboo/app/data/mapper/auth/AuthMapper.kt
+++ b/app/src/main/java/com/byeboo/app/data/mapper/auth/AuthMapper.kt
@@ -18,7 +18,6 @@ fun KakaoLoginResponseDto.toDomain(): AuthResult = AuthResult(
 internal fun String?.toJourneyType(): JourneyType = when(this) {
     "FACE_EMOTION" -> JourneyType.FACE_EMOTION
     "PROCESS_EMOTION" -> JourneyType.PROCESS_EMOTION
-    null -> JourneyType.UNKNOWN
     else -> JourneyType.UNKNOWN
 }
 
@@ -26,7 +25,6 @@ internal fun String?.toJourneyStatus(): JourneyStatusType = when (this) {
     "BEFORE_START" -> JourneyStatusType.BEFORE_START
     "IN_PROGRESS"  -> JourneyStatusType.IN_PROGRESS
     "COMPLETED"    -> JourneyStatusType.COMPLETED
-    null -> JourneyStatusType.UNKNOWN
     else -> JourneyStatusType.UNKNOWN
 }
 

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/AuthRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.byeboo.app.data.repositoryimpl.auth
 
-import android.util.Log
 import com.byeboo.app.core.model.auth.TokenEntity
 import com.byeboo.app.data.datasource.remote.auth.AuthRemoteDataSource
 import com.byeboo.app.data.mapper.auth.toDomain

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestStateRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestStateRepositoryImpl.kt
@@ -31,6 +31,10 @@ class QuestStateRepositoryImpl @Inject constructor(
         return userLocalDataSource.getJourney()
     }
 
+    override suspend fun getUserJourneyStatus(): String? {
+        return userLocalDataSource.getJourneyStatus()
+    }
+
     override suspend fun getQuestDialogue(): Result<QuestDialogue> {
         return runCatching {
             val response = questStateDataSource.getQuestDialogue()

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestStateRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestStateRepositoryImpl.kt
@@ -19,9 +19,12 @@ class QuestStateRepositoryImpl @Inject constructor(
         }
     }
 
-
     override suspend fun updateUserJourney(journey: String) {
         userLocalDataSource.saveJourney(journey)
+    }
+
+    override suspend fun updateUserJourneyStatus(journeyStatus: String) {
+        userLocalDataSource.saveJourneyStatus(journeyStatus)
     }
 
     override suspend fun getUserJourney(): String? {

--- a/app/src/main/java/com/byeboo/app/domain/model/auth/AuthResult.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/auth/AuthResult.kt
@@ -4,5 +4,38 @@ import com.byeboo.app.core.model.auth.TokenEntity
 
 data class AuthResult(
     val tokens: TokenEntity,
-    val isRegistered: Boolean
+    val isRegistered: Boolean,
+    val name: String?,
+    val journey: JourneyType,
+    val journeyStatus: JourneyStatusType
 )
+
+enum class JourneyType(val journeyType: String){
+    FACE_EMOTION("감정 직면"),
+    PROCESS_EMOTION("감정 정리"),
+    UNKNOWN("알 수 없음");
+}
+enum class JourneyStatusType(val journeyStatusType: String){
+    BEFORE_START("진행 직전"),
+    IN_PROGRESS("진행 중"),
+    COMPLETED("진행 완료"),
+    UNKNOWN("알 수 없음");
+}
+
+fun JourneyType.toJourneyText(): String {
+    return when(this) {
+        JourneyType.FACE_EMOTION -> "감정 직면"
+        JourneyType.PROCESS_EMOTION -> "감정 정리"
+        JourneyType.UNKNOWN -> "알 수 없음"
+    }
+}
+
+fun JourneyStatusType.toJourneyStatusText(): String {
+    return when(this) {
+        JourneyStatusType.BEFORE_START -> "진행 직전"
+        JourneyStatusType.IN_PROGRESS -> "진행 중"
+        JourneyStatusType.COMPLETED -> "진행 완료"
+        JourneyStatusType.UNKNOWN -> "알 수 없음"
+    }
+}
+

--- a/app/src/main/java/com/byeboo/app/domain/model/auth/AuthResult.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/auth/AuthResult.kt
@@ -10,16 +10,16 @@ data class AuthResult(
     val journeyStatus: JourneyStatusType
 )
 
-enum class JourneyType(val journeyType: String){
-    FACE_EMOTION("감정 직면"),
-    PROCESS_EMOTION("감정 정리"),
-    UNKNOWN("알 수 없음");
+enum class JourneyType {
+    FACE_EMOTION,
+    PROCESS_EMOTION,
+    UNKNOWN;
 }
-enum class JourneyStatusType(val journeyStatusType: String){
-    BEFORE_START("진행 직전"),
-    IN_PROGRESS("진행 중"),
-    COMPLETED("진행 완료"),
-    UNKNOWN("알 수 없음");
+enum class JourneyStatusType {
+    BEFORE_START,
+    IN_PROGRESS,
+    COMPLETED,
+    UNKNOWN;
 }
 
 fun JourneyType.toJourneyText(): String {
@@ -27,15 +27,6 @@ fun JourneyType.toJourneyText(): String {
         JourneyType.FACE_EMOTION -> "감정 직면"
         JourneyType.PROCESS_EMOTION -> "감정 정리"
         JourneyType.UNKNOWN -> "알 수 없음"
-    }
-}
-
-fun JourneyStatusType.toJourneyStatusText(): String {
-    return when(this) {
-        JourneyStatusType.BEFORE_START -> "진행 직전"
-        JourneyStatusType.IN_PROGRESS -> "진행 중"
-        JourneyStatusType.COMPLETED -> "진행 완료"
-        JourneyStatusType.UNKNOWN -> "알 수 없음"
     }
 }
 

--- a/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestStateRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestStateRepository.kt
@@ -6,6 +6,7 @@ import com.byeboo.app.domain.model.quest.QuestStateModel
 interface QuestStateRepository {
     suspend fun updateQuestState()
     suspend fun updateUserJourney(journey: String)
+    suspend fun updateUserJourneyStatus(journeyStatus: String)
     suspend fun getUserJourney(): String?
     suspend fun getQuestDialogue(): Result<QuestDialogue>
     suspend fun getQuestCount(): Result<QuestStateModel>

--- a/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestStateRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestStateRepository.kt
@@ -8,6 +8,7 @@ interface QuestStateRepository {
     suspend fun updateUserJourney(journey: String)
     suspend fun updateUserJourneyStatus(journeyStatus: String)
     suspend fun getUserJourney(): String?
+    suspend fun getUserJourneyStatus(): String?
     suspend fun getQuestDialogue(): Result<QuestDialogue>
     suspend fun getQuestCount(): Result<QuestStateModel>
     suspend fun isQuestStarted(): Boolean

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
@@ -31,7 +31,6 @@ class LoginUseCase @Inject constructor(
 
             auth.name?.let { userRepository.updateUserNickname(it) }
             questStateRepository.updateUserJourney(auth.journey.toJourneyText())
-            questStateRepository.updateUserJourneyStatus(auth.journeyStatus.name)
 
             auth
         }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
@@ -2,13 +2,19 @@ package com.byeboo.app.domain.usecase
 
 import com.byeboo.app.core.model.auth.TokenEntity
 import com.byeboo.app.domain.model.auth.AuthResult
+import com.byeboo.app.domain.model.auth.toJourneyText
+import com.byeboo.app.domain.model.auth.toJourneyStatusText
 import com.byeboo.app.domain.repository.auth.AuthRepository
 import com.byeboo.app.domain.repository.auth.TokenRepository
+import com.byeboo.app.domain.repository.auth.UserRepository
+import com.byeboo.app.domain.repository.quest.QuestStateRepository
 import javax.inject.Inject
 
 class LoginUseCase @Inject constructor(
     private val authRepository: AuthRepository,
-    private val tokenRepository: TokenRepository
+    private val tokenRepository: TokenRepository,
+    private val userRepository: UserRepository,
+    private val questStateRepository: QuestStateRepository
 ) {
     suspend operator fun invoke(
         token: String, platform: String
@@ -19,10 +25,16 @@ class LoginUseCase @Inject constructor(
         ).mapCatching { auth ->
             tokenRepository.saveTokens(
                 TokenEntity(
-                    accessToken = auth.tokens.accessToken, refreshToken = auth.tokens.refreshToken
+                    accessToken = auth.tokens.accessToken,
+                    refreshToken = auth.tokens.refreshToken
                 )
             )
-            AuthResult(tokens = auth.tokens, isRegistered = auth.isRegistered)
+
+            auth.name?.let { userRepository.updateUserNickname(it) }
+            questStateRepository.updateUserJourney(auth.journey.toJourneyText())
+            questStateRepository.updateUserJourneyStatus(auth.journeyStatus.toJourneyStatusText())
+
+            auth
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
@@ -3,7 +3,6 @@ package com.byeboo.app.domain.usecase
 import com.byeboo.app.core.model.auth.TokenEntity
 import com.byeboo.app.domain.model.auth.AuthResult
 import com.byeboo.app.domain.model.auth.toJourneyText
-import com.byeboo.app.domain.model.auth.toJourneyStatusText
 import com.byeboo.app.domain.repository.auth.AuthRepository
 import com.byeboo.app.domain.repository.auth.TokenRepository
 import com.byeboo.app.domain.repository.auth.UserRepository
@@ -32,7 +31,7 @@ class LoginUseCase @Inject constructor(
 
             auth.name?.let { userRepository.updateUserNickname(it) }
             questStateRepository.updateUserJourney(auth.journey.toJourneyText())
-            questStateRepository.updateUserJourneyStatus(auth.journeyStatus.toJourneyStatusText())
+            questStateRepository.updateUserJourneyStatus(auth.journeyStatus.name)
 
             auth
         }


### PR DESCRIPTION
## Related issue 🛠
- closed #165

## Work Description 📝
- 로컬에 닉네임, 여정 상태 정보 저장해놨어요!

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅


## PR Point 📌
자동로그인은 기획쌤과 상의할 것도 있고..새로 브랜치 파서 하기로 했습니다...

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카카오 로그인에서 사용자 이름, 여정 유형, 여정 진행 상태 정보를 수신해 반영합니다.
  - 로그인 시 사용자 닉네임이 자동으로 업데이트됩니다.
  - 여정 정보(유형)과 여정 진행 상태를 로컬에 저장·조회할 수 있는 기능을 추가했습니다.
- Refactor
  - 인증 결과에 여정 메타데이터(유형·진행 상태)를 통합해 화면 개인화 연동을 개선했습니다.
- Chores
  - 불필요한 코드 정리로 가독성 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->