### PR TITLE
[feat/#169] 자동 로그인 구현

### DIFF
--- a/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
@@ -15,9 +15,7 @@ class LoginUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val questStateRepository: QuestStateRepository
 ) {
-    suspend operator fun invoke(
-        token: String, platform: String
-    ): Result<AuthResult> {
+    suspend operator fun invoke(token: String, platform: String): Result<AuthResult> {
         return authRepository.loginWithKakao(
             token = token,
             platform = platform

--- a/app/src/main/java/com/byeboo/app/domain/usecase/ReissueAccessTokenUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/ReissueAccessTokenUseCase.kt
@@ -1,0 +1,23 @@
+package com.byeboo.app.domain.usecase
+
+import com.byeboo.app.core.model.auth.TokenEntity
+import com.byeboo.app.domain.repository.auth.AuthRepository
+import com.byeboo.app.domain.repository.auth.TokenRepository
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+class ReissueAccessTokenUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val tokenRepository: TokenRepository
+) {
+    suspend operator fun invoke(): Result<TokenEntity> {
+        val refreshToken = tokenRepository.getRefreshToken().firstOrNull().orEmpty()
+        if (refreshToken.isBlank()) {
+            return Result.failure(IllegalStateException("No RefreshToken"))
+        }
+
+        return authRepository.reissueAccessToken(refreshToken)
+            .onSuccess { tokenRepository.saveTokens(it) }
+    }
+
+}

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
@@ -1,6 +1,9 @@
 package com.byeboo.app.presentation.splash
 
-import android.app.ProgressDialog.show
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -10,6 +13,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,9 +21,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -35,6 +44,7 @@ import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.kakao.sdk.user.UserApiClient
+import kotlinx.coroutines.delay
 
 
 @Composable
@@ -49,10 +59,14 @@ fun SplashRoute(
 
     val context = LocalContext.current
     val showSnackBar = LocalSnackBarTrigger.current
+    var showLoginButton by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
+                is SplashStateSideEffect.ShowLoginButton -> {
+                    showLoginButton = true
+                }
                 is SplashStateSideEffect.NavigateToHome -> navigateToHome()
                 is SplashStateSideEffect.NavigateToUserInfo -> navigateToUserInfo()
                 is SplashStateSideEffect.NavigateToTermsOfService -> navigateToTermsOfService()
@@ -75,19 +89,34 @@ fun SplashRoute(
 
     SplashScreen(
         padding = padding,
+        showLoginButton = showLoginButton,
         onClick = {
-            viewModel.startKakaoLogin(UserApiClient.instance.isKakaoTalkLoginAvailable(context))
+            val availableButton = UserApiClient.instance.isKakaoTalkLoginAvailable(context)
+            viewModel.startKakaoLogin(availableButton)
         },
-        modifier = modifier,
+        modifier = modifier
     )
 }
 
 @Composable
 private fun SplashScreen(
     padding: Dp,
+    showLoginButton: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val upAnimation by animateDpAsState(
+        targetValue = if (showLoginButton) (-24).dp else 0.dp,
+        animationSpec = tween(durationMillis = 600, easing = FastOutSlowInEasing),
+        label = "upShift"
+    )
+
+    val buttonAlpha by animateDpAsState(
+        targetValue = if (showLoginButton) 1.dp else 0.dp,
+        animationSpec = tween(durationMillis = 450, delayMillis = 120, easing = LinearOutSlowInEasing),
+        label = "buttonAlpha"
+    )
+
     Box(
         modifier = modifier.fillMaxSize()
     ) {
@@ -104,39 +133,44 @@ private fun SplashScreen(
             modifier = Modifier
                 .padding(horizontal = screenWidthDp(76.dp))
                 .padding(top = screenHeightDp(padding + 250.dp))
+                .offset(y = upAnimation)
         )
 
         Column(
             modifier = Modifier
                 .padding(horizontal = 24.dp)
-                .padding(bottom = padding),
+                .padding(bottom = padding)
+                .offset(y = upAnimation),
         ) {
 
             Spacer(modifier = Modifier.weight(1f))
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(color = ByeBooTheme.colors.kakaoYellow)
-                    .noRippleClickable(onClick = onClick)
-                    .padding(vertical = 16.dp)
-                ,
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_kakao_logo),
-                    contentDescription = "kakao logo"
-                )
+            if (showLoginButton) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color = ByeBooTheme.colors.kakaoYellow)
+                        .graphicsLayer{ alpha = buttonAlpha.toPx() }
+                        .noRippleClickable(onClick = onClick)
+                        .padding(vertical = 16.dp)
+                    ,
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_kakao_logo),
+                        contentDescription = "kakao logo"
+                    )
 
-                Spacer(modifier = Modifier.width(16.dp))
+                    Spacer(modifier = Modifier.width(16.dp))
 
-                Text(
-                    text = "Kakao로 시작하기",
-                    style = ByeBooTheme.typography.body2,
-                    color = ByeBooTheme.colors.black
-                )
+                    Text(
+                        text = "Kakao로 시작하기",
+                        style = ByeBooTheme.typography.body2,
+                        color = ByeBooTheme.colors.black
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
@@ -44,8 +44,6 @@ import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.kakao.sdk.user.UserApiClient
-import kotlinx.coroutines.delay
-
 
 @Composable
 fun SplashRoute(

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashState.kt
@@ -1,6 +1,7 @@
 package com.byeboo.app.presentation.splash
 
 sealed interface SplashStateSideEffect {
+    data object ShowLoginButton : SplashStateSideEffect
     data object NavigateToHome : SplashStateSideEffect
     data object NavigateToUserInfo : SplashStateSideEffect
     data object NavigateToTermsOfService : SplashStateSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.domain.repository.auth.TokenRepository
 import com.byeboo.app.domain.usecase.LoginUseCase
+import com.byeboo.app.domain.usecase.ReissueAccessTokenUseCase
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.AuthError
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
@@ -19,7 +19,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val tokenRepository: TokenRepository,
-    private val loginUseCase: LoginUseCase
+    private val loginUseCase: LoginUseCase,
+    private val reissueAccessTokenUseCase: ReissueAccessTokenUseCase
 ) : ViewModel() {
 
     private val _sideEffect = MutableSharedFlow<SplashStateSideEffect>()
@@ -29,7 +30,26 @@ class SplashViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             tokenRepository.initCachedAccessToken()
+            startAutoLogin()
         }
+    }
+
+    private suspend fun startAutoLogin() {
+        val cachedToken = tokenRepository.getCachedAccessToken()
+
+        if (cachedToken.isNotBlank()) {
+            _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
+            return
+        }
+
+        reissueAccessTokenUseCase()
+            .onSuccess {
+                _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
+            }
+            .onFailure {
+                _sideEffect.emit(SplashStateSideEffect.ShowLoginButton)
+            }
+
     }
 
     fun startKakaoLogin(isLoginAvailable: Boolean) {

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
@@ -10,6 +10,7 @@ import com.kakao.sdk.common.model.AuthError
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -36,6 +37,8 @@ class SplashViewModel @Inject constructor(
 
     private suspend fun startAutoLogin() {
         val cachedToken = tokenRepository.getCachedAccessToken()
+
+        delay(1000)
 
         if (cachedToken.isNotBlank()) {
             _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
@@ -77,7 +80,6 @@ class SplashViewModel @Inject constructor(
                             SplashStateSideEffect.ShowSnackBar("서버에 연결할 수 없습니다. 잠시 후 시도해 주세요.")
                         )
                     }
-                return@launch
 
                 when (error) {
                     is ClientError -> {


### PR DESCRIPTION
## Related issue 🛠
- closed #169 

## Work Description 📝
- reissueAccessToken UseCase 생성
- 자동 로그인 분기 처리
- 애니메이션 추가

## Screenshot 📸

https://github.com/user-attachments/assets/453bb168-ffef-4682-8150-efc7a7992e6f


https://github.com/user-attachments/assets/e2543ed5-45b6-417a-8bf2-28fb7da02be0



## Uncompleted Tasks 😅

## PR Point 📌
- 회원가입 되어있을 때 -> 홈으로 이동
- 회원가입이 되어있지만 앱 삭제 후, 재설치 했을 때 -> 로그인 버튼 등장 -> 홈으로 이동
 
애니메이션 디자인적인 부분은 일단 API 연동 완료한 후에 QA 때 같이 수정하는 걸로 할게요! 
감안 부탁...

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 앱 실행 시 자동 로그인 시도 및 토큰 재발급으로 인증 복구를 시도해 홈 화면으로 빠르게 진입합니다.
- UI/UX
  - 스플래시 화면에서 로그인 버튼을 단계적으로 지연 노출하며 슬라이드·페이드 애니메이션이 적용됩니다.
  - 로그인 가능 여부에 따라 적절한 로그인 흐름을 자동으로 처리합니다.
- 스타일
  - 메서드 선언 형식 정리로 가독성이 향상되었습니다(동작 변경 없음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->