### PR TITLE
[mod/#172] 자동로그인 qa 반영

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/datasource/local/UserLocalDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/local/UserLocalDataSource.kt
@@ -20,4 +20,6 @@ interface UserLocalDataSource {
     suspend fun setHasSeenAboutHelp(seen: Boolean)
     suspend fun hasSeenAboutHelp(): Boolean
     suspend fun clear()
+    suspend fun isUserRegistered(): Boolean
+    suspend fun setUserRegistered(isRegistered: Boolean)
 }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/UserLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/UserLocalDataSourceImpl.kt
@@ -111,6 +111,16 @@ class UserLocalDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun isUserRegistered(): Boolean {
+        return dataStore.data.first()[IS_USER_REGISTERED] ?: false
+    }
+
+    override suspend fun setUserRegistered(isRegistered: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[IS_USER_REGISTERED] = isRegistered
+        }
+    }
+
 
     companion object {
         private val IS_LOGGED_IN = booleanPreferencesKey("IS_LOGGED_IN")
@@ -120,5 +130,6 @@ class UserLocalDataSourceImpl @Inject constructor(
         private val JOURNEY = stringPreferencesKey("JOURNEY")
         private val HAS_SEEN_ABOUT_HELP = booleanPreferencesKey("HAS_SEEN_ABOUT_HELP")
         private val JOURNEY_STATUS = stringPreferencesKey("JOURNEY_STATUS")
+        private val IS_USER_REGISTERED = booleanPreferencesKey("IS_USER_REGISTERED")
     }
 }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/UserRepositoryImpl.kt
@@ -69,4 +69,12 @@ class UserRepositoryImpl @Inject constructor(
              userLocalDataSource.saveNickname(nickname)
          }
     }
+
+    override suspend fun isUserRegistered(): Boolean {
+        return userLocalDataSource.isUserRegistered()
+    }
+
+    override suspend fun setUserRegistered(isRegistered: Boolean) {
+        userLocalDataSource.setUserRegistered(isRegistered)
+    }
 }

--- a/app/src/main/java/com/byeboo/app/domain/repository/auth/UserRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/auth/UserRepository.kt
@@ -16,4 +16,6 @@ interface UserRepository {
     suspend fun hasSeenAboutHelp(): Boolean
     suspend fun clear()
     suspend fun updateUserNickname(nickname: String): Result<Unit>
+    suspend fun isUserRegistered(): Boolean
+    suspend fun setUserRegistered(isRegistered: Boolean)
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LoginUseCase.kt
@@ -29,6 +29,7 @@ class LoginUseCase @Inject constructor(
 
             auth.name?.let { userRepository.updateUserNickname(it) }
             questStateRepository.updateUserJourney(auth.journey.toJourneyText())
+            userRepository.setUserRegistered(auth.isRegistered)
 
             auth
         }

--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoViewModel.kt
@@ -86,6 +86,7 @@ class UserInfoViewModel @Inject constructor(
             if (result.isSuccess) {
                 _uiState.value.selectedQuest?.let {
                     questStateRepository.updateUserJourney(it.toJourneyText())
+                    userRepository.setUserRegistered(true)
                 }
                 _sideEffect.emit(UserInfoSideEffect.NavigateToLoading)
             } else {

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
@@ -2,7 +2,9 @@ package com.byeboo.app.presentation.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.byeboo.app.domain.model.auth.AuthResult
 import com.byeboo.app.domain.repository.auth.TokenRepository
+import com.byeboo.app.domain.repository.auth.UserRepository
 import com.byeboo.app.domain.usecase.LoginUseCase
 import com.byeboo.app.domain.usecase.ReissueAccessTokenUseCase
 import com.kakao.sdk.auth.model.OAuthToken
@@ -20,6 +22,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val tokenRepository: TokenRepository,
+    private val userRepository: UserRepository,
     private val loginUseCase: LoginUseCase,
     private val reissueAccessTokenUseCase: ReissueAccessTokenUseCase
 ) : ViewModel() {
@@ -35,7 +38,7 @@ class SplashViewModel @Inject constructor(
         }
     }
 
-    private suspend fun startAutoLogin() {
+    /*private suspend fun startAutoLogin() {
         val cachedToken = tokenRepository.getCachedAccessToken()
 
         delay(1000)
@@ -53,6 +56,36 @@ class SplashViewModel @Inject constructor(
                 _sideEffect.emit(SplashStateSideEffect.ShowLoginButton)
             }
 
+    }
+
+     */
+
+    private suspend fun startAutoLogin() {
+        val cachedToken = tokenRepository.getCachedAccessToken()
+
+        if (cachedToken.isNotBlank()) {
+            val isRegistered = userRepository.isUserRegistered()
+
+            if (isRegistered) {
+                _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
+            } else {
+                _sideEffect.emit(SplashStateSideEffect.ShowLoginButton)
+            }
+            return
+        }
+
+        reissueAccessTokenUseCase()
+            .onSuccess {
+                val isRegistered = userRepository.isUserRegistered()
+                if (isRegistered) {
+                    _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
+                } else {
+                    _sideEffect.emit(SplashStateSideEffect.ShowLoginButton)
+                }
+            }
+            .onFailure {
+                _sideEffect.emit(SplashStateSideEffect.ShowLoginButton)
+            }
     }
 
     fun startKakaoLogin(isLoginAvailable: Boolean) {


### PR DESCRIPTION
## Related issue 🛠
- closed #172 

## Work Description 📝
- 자동로그인 QA 반영

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## PR Point 📌

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 사용자 등록 여부를 로컬에 저장/조회해 상태를 유지합니다.
  - 스플래시에서 액세스 토큰과 등록 상태를 함께 확인해 자동으로 홈 이동 또는 로그인 버튼 표시를 지원합니다.
- Refactor
  - 자동 로그인 흐름을 등록 상태 기반으로 재구성하고 불필요한 지연을 제거했습니다.
  - 로그인/회원정보 완료 시 등록 상태를 갱신하도록 정리해 초기 진입 동선을 일관되게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->