### PR TITLE
[fix/#174] 홈 화면 오류 수정

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/dto/response/quest/QuestCountResponseDto.kt
+++ b/app/src/main/java/com/byeboo/app/data/dto/response/quest/QuestCountResponseDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class QuestCountResponseDto(
     @SerialName("todayComplete")
-    val todayComplete: Boolean,
+    val todayComplete: Boolean?,
     @SerialName("userCurrentStatus")
     val userCurrentStatus: String,
     @SerialName("count")

--- a/app/src/main/java/com/byeboo/app/domain/model/quest/QuestData.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/quest/QuestData.kt
@@ -3,5 +3,4 @@ package com.byeboo.app.domain.model.quest
 data class QuestData(
     val inProgressQuest: QuestInProgressModel,
     val journeyTitle: String,
-    val userNickname: String
 )

--- a/app/src/main/java/com/byeboo/app/domain/model/quest/QuestStateModel.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/quest/QuestStateModel.kt
@@ -1,7 +1,7 @@
 package com.byeboo.app.domain.model.quest
 
 data class QuestStateModel(
-    val todayComplete: Boolean,
+    val todayComplete: Boolean?,
     val userCurrentStatus: String,
     val count: Int
 )

--- a/app/src/main/java/com/byeboo/app/domain/usecase/QuestUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/QuestUseCase.kt
@@ -1,25 +1,20 @@
 package com.byeboo.app.domain.usecase
 
 import com.byeboo.app.domain.model.quest.QuestData
-import com.byeboo.app.domain.repository.auth.UserRepository
 import com.byeboo.app.domain.repository.quest.QuestInProgressRepository
 import com.byeboo.app.domain.repository.quest.QuestStateRepository
 import javax.inject.Inject
-import kotlinx.coroutines.flow.firstOrNull
 
 class QuestUseCase @Inject constructor(
     private val questInProgressRepository: QuestInProgressRepository,
     private val questStateRepository: QuestStateRepository,
-    private val userRepository: UserRepository
 ) {
     suspend operator fun invoke(): QuestData {
         val result = questInProgressRepository.getInProgressQuest().getOrThrow()
         val journey = questStateRepository.getUserJourney() ?: ""
-        val nickname = userRepository.getNickname().firstOrNull() ?: ""
         return QuestData(
             inProgressQuest = result,
-            journeyTitle = journey,
-            userNickname = nickname
+            journeyTitle = journey
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/QuestViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/QuestViewModel.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.presentation.quest
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.core.model.quest.QuestType
+import com.byeboo.app.domain.repository.auth.UserRepository
 import com.byeboo.app.domain.usecase.QuestUseCase
 import com.byeboo.app.presentation.quest.model.QuestSideEffect
 import com.byeboo.app.presentation.quest.model.QuestState
@@ -27,7 +28,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class QuestViewModel @Inject constructor(
     private val questUseCase: QuestUseCase,
-    private val mapper: QuestUiModelMapper
+    private val mapper: QuestUiModelMapper,
+    private val userRepository: UserRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(QuestUiState())
@@ -39,6 +41,13 @@ class QuestViewModel @Inject constructor(
     private var countdownJob: Job? = null
 
     init {
+        viewModelScope.launch {
+            userRepository.getNickname().collect { nickname ->
+                _uiState.update {
+                    it.copy(userName = nickname)
+                }
+            }
+        }
         loadQuests()
     }
 
@@ -53,7 +62,6 @@ class QuestViewModel @Inject constructor(
                             currentStepIndex = output.activeStepIndex,
                             progressPeriod = output.progressPeriod,
                             journeyTitle = output.journeyTitle,
-                            userName = output.userName,
                             error = null
                         )
                     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/model/QuestOutput.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/model/QuestOutput.kt
@@ -10,6 +10,5 @@ data class QuestOutput(
     val openAt: Instant?,
     val serverNow: Instant?,
     val progressPeriod: Long,
-    val journeyTitle: String,
-    val userName: String
+    val journeyTitle: String
 )

--- a/app/src/main/java/com/byeboo/app/presentation/quest/util/QuestMapper.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/util/QuestMapper.kt
@@ -55,8 +55,7 @@ class QuestUiModelMapper @Inject constructor() {
             openAt = openAt,
             serverNow = serverNow,
             progressPeriod = inProgress.progressPeriod,
-            journeyTitle = data.journeyTitle,
-            userName = data.userNickname
+            journeyTitle = data.journeyTitle
         )
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #174

## Work Description 📝
- 퀘스트 화면 닉네임 수집 로직 변경
- 서버 응답값에 따른 dto, model 수정

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/b3fc6999-afd0-4b5f-8127-c3e7aed63e1e" width="360"/>

## PR Point 📌
닉네임이 실시간으로 퀘스트 화면에 반영되도록 수정하였습니다.
퀘스트 30개를 완료했을 때, 서버 호출 실패하던 문제를 발견하고,
`todayComplete`응답 값이 `null` 로 오는 것을 방금 확인하여 수정했습니다.

## 트러블 슈팅 💥
Expected valid boolean literal prefix, but had 'null' at path: $.data.todayComplete
`non-nullable`로 저장하던 응답 값 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 없음

- 개선/리팩터
  - 사용자 닉네임이 프로필 변화에 따라 퀘스트 화면에 실시간으로 반영되도록 동작을 정비했습니다.
  - 퀘스트 진행 정보 구조를 단순화해 전반적인 응답 처리 안정성을 높였습니다.

- 버그 수정
  - 일부 상황에서 “오늘 완료” 상태가 제공되지 않을 때 발생할 수 있던 오류를 방지하여 앱 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->