### PR TITLE
[feat/#168] 로그아웃, 회원탈퇴 api 연동

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/datasource/local/TokenDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/local/TokenDataSource.kt
@@ -7,4 +7,6 @@ interface TokenDataSource {
     fun getRefreshToken(): Flow<String>
     suspend fun updateTokens(accessToken: String, refreshToken: String)
     suspend fun clearTokens()
+    suspend fun setLoginSplash(show: Boolean)
+    suspend fun restartSplash(): Boolean
 }

--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/auth/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/auth/AuthRemoteDataSource.kt
@@ -1,12 +1,13 @@
 package com.byeboo.app.data.datasource.remote.auth
 
 import com.byeboo.app.data.dto.base.BaseResponse
+import com.byeboo.app.data.dto.base.NullableBaseResponse
 import com.byeboo.app.data.dto.response.auth.KakaoLoginResponseDto
 import com.byeboo.app.data.dto.response.auth.TokenReissueResponseDto
 
 interface AuthRemoteDataSource {
     suspend fun loginWithKakao(token: String, platform: String): BaseResponse<KakaoLoginResponseDto>
     suspend fun reissueAccessToken(refreshToken: String): BaseResponse<TokenReissueResponseDto>
-    suspend fun logoutAccount(): BaseResponse<Unit>
-    suspend fun withdrawAccount(): BaseResponse<Unit>
+    suspend fun logoutAccount(token: String): NullableBaseResponse<Unit>
+    suspend fun withdrawAccount(token: String): NullableBaseResponse<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/auth/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/auth/AuthRemoteDataSource.kt
@@ -7,4 +7,6 @@ import com.byeboo.app.data.dto.response.auth.TokenReissueResponseDto
 interface AuthRemoteDataSource {
     suspend fun loginWithKakao(token: String, platform: String): BaseResponse<KakaoLoginResponseDto>
     suspend fun reissueAccessToken(refreshToken: String): BaseResponse<TokenReissueResponseDto>
+    suspend fun logoutAccount(): BaseResponse<Unit>
+    suspend fun withdrawAccount(): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/TokenDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/local/TokenDataSourceImpl.kt
@@ -2,11 +2,11 @@ package com.byeboo.app.data.datasourceimpl.local
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.byeboo.app.data.datasource.local.TokenDataSource
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -36,9 +36,23 @@ class TokenDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun setLoginSplash(show: Boolean) {
+        datastore.edit { it[SHOW_LOGIN_BUTTON] = show }
+    }
+
+    override suspend fun restartSplash(): Boolean {
+        var showButton = false
+        datastore.edit {
+            showButton = it[SHOW_LOGIN_BUTTON] ?: false
+            if (showButton) it[SHOW_LOGIN_BUTTON] = false
+        }
+        return showButton
+    }
+
     companion object {
         private val ACCESS_TOKEN = stringPreferencesKey("ACCESS_TOKEN")
         private val REFRESH_TOKEN = stringPreferencesKey("REFRESH_TOKEN")
+        private val SHOW_LOGIN_BUTTON = booleanPreferencesKey("SHOW_LOGIN_BUTTON")
     }
 
 }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/auth/AuthRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/auth/AuthRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.byeboo.app.data.datasourceimpl.remote.auth
 
 import com.byeboo.app.data.datasource.remote.auth.AuthRemoteDataSource
 import com.byeboo.app.data.dto.base.BaseResponse
+import com.byeboo.app.data.dto.base.NullableBaseResponse
 import com.byeboo.app.data.dto.request.auth.KakaoLoginRequestDto
 import com.byeboo.app.data.dto.response.auth.KakaoLoginResponseDto
 import com.byeboo.app.data.dto.response.auth.TokenReissueResponseDto
@@ -23,12 +24,12 @@ class AuthRemoteDataSourceImpl @Inject constructor(
     override suspend fun reissueAccessToken(refreshToken: String): BaseResponse<TokenReissueResponseDto> =
        authService.reissueAccessToken("$BEARER $refreshToken")
 
-    override suspend fun logoutAccount(): BaseResponse<Unit> =
-        authService.logoutAccount()
+    override suspend fun logoutAccount(token: String): NullableBaseResponse<Unit> =
+        authService.logoutAccount("$BEARER $token")
 
 
-    override suspend fun withdrawAccount(): BaseResponse<Unit> =
-        authService.withdrawAccount()
+    override suspend fun withdrawAccount(token: String): NullableBaseResponse<Unit> =
+        authService.withdrawAccount("$BEARER $token")
 
 
     companion object {

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/auth/AuthRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/auth/AuthRemoteDataSourceImpl.kt
@@ -23,6 +23,14 @@ class AuthRemoteDataSourceImpl @Inject constructor(
     override suspend fun reissueAccessToken(refreshToken: String): BaseResponse<TokenReissueResponseDto> =
        authService.reissueAccessToken("$BEARER $refreshToken")
 
+    override suspend fun logoutAccount(): BaseResponse<Unit> =
+        authService.logoutAccount()
+
+
+    override suspend fun withdrawAccount(): BaseResponse<Unit> =
+        authService.withdrawAccount()
+
+
     companion object {
         private const val BEARER = "Bearer"
     }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/AuthRepositoryImpl.kt
@@ -22,4 +22,15 @@ class AuthRepositoryImpl @Inject constructor(
         runCatching {
             authRemoteDataSource.reissueAccessToken(refreshToken).data.toDomain()
     }
+
+    override suspend fun logoutAccount(): Result<Unit> =
+        runCatching {
+            authRemoteDataSource.logoutAccount()
+
+    }
+
+    override suspend fun withdrawAccount(): Result<Unit> =
+        runCatching {
+            authRemoteDataSource.withdrawAccount()
+    }
 }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/AuthRepositoryImpl.kt
@@ -23,14 +23,14 @@ class AuthRepositoryImpl @Inject constructor(
             authRemoteDataSource.reissueAccessToken(refreshToken).data.toDomain()
     }
 
-    override suspend fun logoutAccount(): Result<Unit> =
+    override suspend fun logoutAccount(token: String): Result<Unit> =
         runCatching {
-            authRemoteDataSource.logoutAccount()
+            authRemoteDataSource.logoutAccount(token)
 
     }
 
-    override suspend fun withdrawAccount(): Result<Unit> =
+    override suspend fun withdrawAccount(token: String): Result<Unit> =
         runCatching {
-            authRemoteDataSource.withdrawAccount()
+            authRemoteDataSource.withdrawAccount(token)
     }
 }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
@@ -36,4 +36,13 @@ class TokenRepositoryImpl @Inject constructor(
     override fun updateCachedAccessToken(token: String) {
         cachedAccessToken = token
     }
+
+    override suspend fun setLoginSplash(show: Boolean) {
+        tokenDataSource.setLoginSplash(show)
+
+    }
+
+    override suspend fun restartSplash(): Boolean =
+        tokenDataSource.restartSplash()
+
 }

--- a/app/src/main/java/com/byeboo/app/data/service/auth/AuthService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/auth/AuthService.kt
@@ -5,6 +5,7 @@ import com.byeboo.app.data.dto.request.auth.KakaoLoginRequestDto
 import com.byeboo.app.data.dto.response.auth.KakaoLoginResponseDto
 import com.byeboo.app.data.dto.response.auth.TokenReissueResponseDto
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.Header
 import retrofit2.http.POST
 
@@ -19,4 +20,10 @@ interface AuthService {
     suspend fun reissueAccessToken(
         @Header("Authorization") authorization: String
     ): BaseResponse<TokenReissueResponseDto>
+
+    @DELETE("/api/v1/auth/logout")
+    suspend fun logoutAccount(): BaseResponse<Unit>
+
+    @DELETE("/api/v1/auth/withdraw")
+    suspend fun withdrawAccount(): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/data/service/auth/AuthService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/auth/AuthService.kt
@@ -1,6 +1,7 @@
 package com.byeboo.app.data.service.auth
 
 import com.byeboo.app.data.dto.base.BaseResponse
+import com.byeboo.app.data.dto.base.NullableBaseResponse
 import com.byeboo.app.data.dto.request.auth.KakaoLoginRequestDto
 import com.byeboo.app.data.dto.response.auth.KakaoLoginResponseDto
 import com.byeboo.app.data.dto.response.auth.TokenReissueResponseDto
@@ -22,8 +23,12 @@ interface AuthService {
     ): BaseResponse<TokenReissueResponseDto>
 
     @DELETE("/api/v1/auth/logout")
-    suspend fun logoutAccount(): BaseResponse<Unit>
+    suspend fun logoutAccount(
+        @Header("Authorization") authorization: String
+    ): NullableBaseResponse<Unit>
 
     @DELETE("/api/v1/auth/withdraw")
-    suspend fun withdrawAccount(): BaseResponse<Unit>
+    suspend fun withdrawAccount(
+        @Header("Authorization") authorization: String
+    ): NullableBaseResponse<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/auth/AuthRepository.kt
@@ -6,6 +6,6 @@ import com.byeboo.app.domain.model.auth.AuthResult
 interface AuthRepository {
     suspend fun loginWithKakao(token: String, platform: String): Result<AuthResult>
     suspend fun reissueAccessToken(refreshToken: String): Result<TokenEntity>
-    suspend fun logoutAccount(): Result<Unit>
-    suspend fun withdrawAccount(): Result<Unit>
+    suspend fun logoutAccount(token: String): Result<Unit>
+    suspend fun withdrawAccount(token: String): Result<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/auth/AuthRepository.kt
@@ -6,4 +6,6 @@ import com.byeboo.app.domain.model.auth.AuthResult
 interface AuthRepository {
     suspend fun loginWithKakao(token: String, platform: String): Result<AuthResult>
     suspend fun reissueAccessToken(refreshToken: String): Result<TokenEntity>
+    suspend fun logoutAccount(): Result<Unit>
+    suspend fun withdrawAccount(): Result<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
@@ -11,4 +11,6 @@ interface TokenRepository {
     suspend fun initCachedAccessToken()
     fun updateCachedAccessToken(token: String)
     fun getCachedAccessToken(): String
+    suspend fun setLoginSplash(show: Boolean)
+    suspend fun restartSplash(): Boolean
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
@@ -10,11 +10,14 @@ class LogoutUseCase @Inject constructor(
     private val tokenRepository: TokenRepository,
     private val userRepository: UserRepository
 ){
-    suspend operator fun invoke(): Result<Unit> {
+    private val accessToken: String
+        get() = tokenRepository.getCachedAccessToken()
 
-        val account = authRepository.logoutAccount()
+    suspend operator fun invoke(): Result<Unit> {
+        val account = authRepository.logoutAccount(accessToken)
         tokenRepository.clearTokens()
         userRepository.clear()
+        tokenRepository.setLoginSplash(true)
 
         return account
     }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.domain.usecase
 import com.byeboo.app.domain.repository.auth.AuthRepository
 import com.byeboo.app.domain.repository.auth.TokenRepository
 import com.byeboo.app.domain.repository.auth.UserRepository
+import com.byeboo.app.presentation.mypage.MyPageSideEffect
 import javax.inject.Inject
 
 class LogoutUseCase @Inject constructor(
@@ -14,11 +15,14 @@ class LogoutUseCase @Inject constructor(
         get() = tokenRepository.getCachedAccessToken()
 
     suspend operator fun invoke(): Result<Unit> {
-        val account = authRepository.logoutAccount(accessToken)
-        tokenRepository.clearTokens()
-        userRepository.clear()
-        tokenRepository.setLoginSplash(true)
-
-        return account
+        return authRepository.logoutAccount(accessToken)
+            .onSuccess {
+                tokenRepository.clearTokens()
+                userRepository.clear()
+                tokenRepository.setLoginSplash(true)
+            }
+            .onFailure {
+                MyPageSideEffect.ShowSnackBar(message = "로그아웃 실패")
+            }
     }
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
@@ -1,0 +1,21 @@
+package com.byeboo.app.domain.usecase
+
+import com.byeboo.app.domain.repository.auth.AuthRepository
+import com.byeboo.app.domain.repository.auth.TokenRepository
+import com.byeboo.app.domain.repository.auth.UserRepository
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val tokenRepository: TokenRepository,
+    private val userRepository: UserRepository
+){
+    suspend operator fun invoke(): Result<Unit> {
+
+        val account = authRepository.logoutAccount()
+        tokenRepository.clearTokens()
+        userRepository.clear()
+
+        return account
+    }
+}

--- a/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
@@ -10,12 +10,15 @@ class WithdrawUseCase @Inject constructor(
     private val tokenRepository: TokenRepository,
     private val userRepository: UserRepository
 ) {
+    private val accessToken: String
+        get() = tokenRepository.getCachedAccessToken()
+
     suspend operator fun invoke(): Result<Unit> {
-        val account = authRepository.withdrawAccount()
+        val account = authRepository.withdrawAccount(accessToken)
         tokenRepository.clearTokens()
         userRepository.clear()
+        tokenRepository.setLoginSplash(true)
 
         return account
     }
-
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
@@ -1,0 +1,21 @@
+package com.byeboo.app.domain.usecase
+
+import com.byeboo.app.domain.repository.auth.AuthRepository
+import com.byeboo.app.domain.repository.auth.TokenRepository
+import com.byeboo.app.domain.repository.auth.UserRepository
+import javax.inject.Inject
+
+class WithdrawUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val tokenRepository: TokenRepository,
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(): Result<Unit> {
+        val account = authRepository.withdrawAccount()
+        tokenRepository.clearTokens()
+        userRepository.clear()
+
+        return account
+    }
+
+}

--- a/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
@@ -14,11 +14,14 @@ class WithdrawUseCase @Inject constructor(
         get() = tokenRepository.getCachedAccessToken()
 
     suspend operator fun invoke(): Result<Unit> {
-        val account = authRepository.withdrawAccount(accessToken)
-        tokenRepository.clearTokens()
-        userRepository.clear()
-        tokenRepository.setLoginSplash(true)
-
-        return account
+        return authRepository.withdrawAccount(accessToken)
+            .onSuccess {
+                tokenRepository.clearTokens()
+                userRepository.clear()
+                tokenRepository.setLoginSplash(true)
+            }
+            .onFailure {
+                //Todo: 스낵바
+            }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -42,7 +42,7 @@ fun MainNavHost(
     val questBehaviorViewModel: QuestBehaviorViewModel = hiltViewModel()
 
     val splashNavOptions = navOptions {
-        popUpTo(Splash) {
+        popUpTo(0) {
             saveState = true
             inclusive = false
         }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -98,6 +98,7 @@ fun MainNavHost(
         myPageGraph(
             bottomPadding = padding,
             navigateToEditProfile = { navigator.navigateToEditProfile(clearStackNavOptions) },
+            navigateToSplash = { navigator.navigateToHomeOnboarding(clearStackNavOptions)},
             navigateToMyPage = { navigator.navigateToMyPage(clearStackNavOptions) }
         )
 

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -15,6 +15,7 @@ import com.byeboo.app.presentation.home.navigation.homeGraph
 import com.byeboo.app.presentation.mypage.navigation.myPageGraph
 import com.byeboo.app.presentation.quest.behavior.QuestBehaviorViewModel
 import com.byeboo.app.presentation.quest.navigation.questGraph
+import com.byeboo.app.presentation.splash.navigation.Splash
 import com.byeboo.app.presentation.splash.navigation.splashGraph
 import com.byeboo.app.presentation.splash.termsofservice.navigation.termsGraph
 
@@ -37,7 +38,17 @@ fun MainNavHost(
         launchSingleTop = true
         restoreState = true
     }
+
     val questBehaviorViewModel: QuestBehaviorViewModel = hiltViewModel()
+
+    val splashNavOptions = navOptions {
+        popUpTo(Splash) {
+            saveState = true
+            inclusive = false
+        }
+        launchSingleTop = true
+        restoreState = false
+    }
 
     NavHost(
         modifier = modifier,
@@ -98,7 +109,7 @@ fun MainNavHost(
         myPageGraph(
             bottomPadding = padding,
             navigateToEditProfile = { navigator.navigateToEditProfile(clearStackNavOptions) },
-            navigateToSplash = { navigator.navigateToHomeOnboarding(clearStackNavOptions)},
+            navigateToSplash = { navigator.navigateToSplash(splashNavOptions)},
             navigateToMyPage = { navigator.navigateToMyPage(clearStackNavOptions) }
         )
 

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
@@ -26,6 +26,7 @@ import com.byeboo.app.presentation.quest.navigation.navigateToQuestTip
 import com.byeboo.app.presentation.quest.record.navigation.navigateToQuestRecording
 import com.byeboo.app.presentation.quest.record.navigation.navigateToQuestRecordingComplete
 import com.byeboo.app.presentation.splash.navigation.Splash
+import com.byeboo.app.presentation.splash.navigation.navigateToSplash
 import com.byeboo.app.presentation.splash.termsofservice.navigation.navigateToTerms
 
 class MainNavigator(
@@ -135,6 +136,10 @@ class MainNavigator(
 
     fun navigateToTerms(navOptions: NavOptions) {
         navController.navigateToTerms(navOptions)
+    }
+
+    fun navigateToSplash(navOptions: NavOptions) {
+        navController.navigateToSplash(navOptions)
     }
 }
 

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -58,7 +58,7 @@ fun MyPageRoute(
             onDismissRequest = { viewModel.onDismissModal(ModalType.LOGOUT) },
             myPageModalMainText = "로그아웃하시겠어요?",
             onCancelClick = { viewModel.onDismissModal(ModalType.LOGOUT) },
-            onConfirmClick = { viewModel.confirmLogout() },
+            onConfirmClick = viewModel::confirmLogout,
             onConfirmText = "로그아웃"
         )
     }
@@ -68,7 +68,7 @@ fun MyPageRoute(
             onDismissRequest = { viewModel.onDismissModal(ModalType.DELETE_ACCOUNT) },
             myPageModalMainText = "정말 탈퇴하시겠어요?",
             onCancelClick = { viewModel.onDismissModal(ModalType.DELETE_ACCOUNT) },
-            onConfirmClick = { viewModel.confirmWithdraw() },
+            onConfirmClick = viewModel::confirmWithdraw,
             onConfirmText = "탈퇴하기",
             myPageModalSubText = "탈퇴 시 모든 데이터가 삭제됩니다."
         )
@@ -79,6 +79,7 @@ fun MyPageRoute(
             when (effect) {
                 is MyPageSideEffect.OpenUrl -> openUrl(context = context, effect.url)
                 is MyPageSideEffect.NavigateToSplash -> navigateToSplash()
+                is MyPageSideEffect.ShowSnackBar -> effect.message
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -43,6 +43,7 @@ import com.byeboo.app.presentation.mypage.component.MyPageModal
 @Composable
 fun MyPageRoute(
     navigateToEditProfile: () -> Unit,
+    navigateToSplash: () -> Unit,
     bottomPadding: Dp,
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel()
@@ -55,7 +56,7 @@ fun MyPageRoute(
             onDismissRequest = { viewModel.onDismissModal(ModalType.LOGOUT) },
             myPageModalMainText = "로그아웃하시겠어요?",
             onCancelClick = { viewModel.onDismissModal(ModalType.LOGOUT) },
-            onConfirmClick = {},
+            onConfirmClick = { viewModel.confirmLogout() },
             onConfirmText = "로그아웃"
         )
     }
@@ -65,7 +66,7 @@ fun MyPageRoute(
             onDismissRequest = { viewModel.onDismissModal(ModalType.DELETE_ACCOUNT) },
             myPageModalMainText = "정말 탈퇴하시겠어요?",
             onCancelClick = { viewModel.onDismissModal(ModalType.DELETE_ACCOUNT) },
-            onConfirmClick = {},
+            onConfirmClick = { viewModel.confirmWithdraw() },
             onConfirmText = "탈퇴하기",
             myPageModalSubText = "탈퇴 시 모든 데이터가 삭제됩니다."
         )
@@ -75,6 +76,7 @@ fun MyPageRoute(
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 is MyPageSideEffect.OpenUrl -> openUrl(context = context, effect.url)
+                is MyPageSideEffect.NavigateToSplash -> navigateToSplash()
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
@@ -50,6 +51,7 @@ fun MyPageRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     if (uiState.showLogoutModal) {
         MyPageModal(
@@ -72,7 +74,7 @@ fun MyPageRoute(
         )
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(lifecycleOwner) {
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 is MyPageSideEffect.OpenUrl -> openUrl(context = context, effect.url)

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageState.kt
@@ -13,4 +13,5 @@ enum class ModalType {
 
 sealed interface MyPageSideEffect {
     data class OpenUrl(val url: String): MyPageSideEffect
+    data object NavigateToSplash: MyPageSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageState.kt
@@ -14,4 +14,5 @@ enum class ModalType {
 sealed interface MyPageSideEffect {
     data class OpenUrl(val url: String): MyPageSideEffect
     data object NavigateToSplash: MyPageSideEffect
+    data class ShowSnackBar(val message: String) : MyPageSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
@@ -19,8 +19,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val userRepository: UserRepository,
-    val logoutUseCase: LogoutUseCase,
-    val withdrawUseCase: WithdrawUseCase
+    private val logoutUseCase: LogoutUseCase,
+    private val withdrawUseCase: WithdrawUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MyPageState())

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.BuildConfig
 import com.byeboo.app.domain.repository.auth.UserRepository
+import com.byeboo.app.domain.usecase.LogoutUseCase
+import com.byeboo.app.domain.usecase.WithdrawUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +18,9 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    val logoutUseCase: LogoutUseCase,
+    val withdrawUseCase: WithdrawUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MyPageState())
@@ -60,6 +64,26 @@ class MyPageViewModel @Inject constructor(
 
     fun onDeleteAccountClicked() {
         _uiState.update { it.copy(showDeleteAccountModal = true) }
+    }
+
+    fun confirmLogout() {
+        viewModelScope.launch {
+            logoutUseCase().onSuccess {
+                _sideEffect.emit(MyPageSideEffect.NavigateToSplash)
+            }.onFailure {
+                //Todo
+            }
+        }
+    }
+
+    fun confirmWithdraw() {
+        viewModelScope.launch {
+            withdrawUseCase().onSuccess {
+                _sideEffect.emit(MyPageSideEffect.NavigateToSplash)
+            }.onFailure {
+                //Todo:
+            }
+        }
     }
 
     fun logout() {

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
@@ -69,6 +69,7 @@ class MyPageViewModel @Inject constructor(
     fun confirmLogout() {
         viewModelScope.launch {
             logoutUseCase().onSuccess {
+                _uiState.update { it.copy(showLogoutModal = false) }
                 _sideEffect.emit(MyPageSideEffect.NavigateToSplash)
             }.onFailure {
                 //Todo
@@ -83,12 +84,6 @@ class MyPageViewModel @Inject constructor(
             }.onFailure {
                 //Todo:
             }
-        }
-    }
-
-    fun logout() {
-        viewModelScope.launch {
-            userRepository.clear()
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/navigation/MypageNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/navigation/MypageNavigation.kt
@@ -23,12 +23,14 @@ fun NavController.navigateToEditProfile(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.myPageGraph(
     navigateToEditProfile: () -> Unit,
+    navigateToSplash: () -> Unit,
     navigateToMyPage: () -> Unit,
     bottomPadding: Dp,
 ) {
     composable<MyPage> {
         MyPageRoute(
             navigateToEditProfile = navigateToEditProfile,
+            navigateToSplash = navigateToSplash,
             bottomPadding = bottomPadding
         )
     }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
@@ -34,31 +34,16 @@ class SplashViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             tokenRepository.initCachedAccessToken()
+
+            if (tokenRepository.restartSplash()) {
+                _sideEffect.emit(SplashStateSideEffect.ShowLoginButton)
+                return@launch
+            }
+
             startAutoLogin()
         }
     }
 
-    /*private suspend fun startAutoLogin() {
-        val cachedToken = tokenRepository.getCachedAccessToken()
-
-        delay(1000)
-
-        if (cachedToken.isNotBlank()) {
-            _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
-            return
-        }
-
-        reissueAccessTokenUseCase()
-            .onSuccess {
-                _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
-            }
-            .onFailure {
-                _sideEffect.emit(SplashStateSideEffect.ShowLoginButton)
-            }
-
-    }
-
-     */
 
     private suspend fun startAutoLogin() {
         val cachedToken = tokenRepository.getCachedAccessToken()

--- a/app/src/main/java/com/byeboo/app/presentation/splash/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/navigation/SplashNavigation.kt
@@ -1,11 +1,17 @@
 package com.byeboo.app.presentation.splash.navigation
 
 import androidx.compose.ui.unit.Dp
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.byeboo.app.core.navigation.Route
 import com.byeboo.app.presentation.splash.SplashRoute
 import kotlinx.serialization.Serializable
+
+fun NavController.navigateToSplash(navOptions: NavOptions) {
+    navigate(Splash, navOptions)
+}
 
 fun NavGraphBuilder.splashGraph(
     navigateToHome: () -> Unit,


### PR DESCRIPTION
## Related issue 🛠
- closed #168 

## Work Description 📝
- 로그아웃, 회원 탈퇴 api 연동
- 로그아웃, 회원 탈퇴 후 스플래시 화면 이동

## Screenshot 📸

<img width="819" height="413" alt="스크린샷 2025-09-05 040935" src="https://github.com/user-attachments/assets/15e70b31-45cd-451b-a520-d8093652ac15" />

https://github.com/user-attachments/assets/2cf6413c-03fd-4574-aeb5-09ee361e7f5e

https://github.com/user-attachments/assets/d4075929-7361-4403-9fb4-1ed7e69d7bc6


## Uncompleted Tasks 😅
- N/A

## PR Point 📌
내일 오후 중에 수정하겠음...pr포인트...
## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 로그아웃/회원탈퇴 지원: 서버 요청 후 로컬 토큰·사용자 데이터 정리 및 결과 반환.
  - 로그아웃/탈퇴 성공 시 스플래시로 이동하고 로그인 버튼 노출.
  - 마이페이지에서 확인 모달로 로그아웃/탈퇴 실행 가능.
  - 스플래시 재시작 플래그: 다음 진입 시 자동로그인 대신 로그인 버튼 우선 표시.
  - 자동로그인 흐름 개선: 토큰 상태에 따라 홈 이동 또는 로그인 버튼 명확화.
  - 내비게이션에 스플래시 경로 추가 및 백스택/상태 동작 최적화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->