### PR TITLE
[fix/#215] 여정 시작 화면 버튼 위치 수정

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -71,52 +72,53 @@ private fun QuestStartScreen(
     padding: Dp,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    LazyColumn(
         modifier = modifier
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
     ) {
-        Row(
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(top = screenHeightDp(67.dp))
-                .padding(horizontal = screenWidthDp(24.dp)),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Icon(
-                imageVector = ImageVector.vectorResource(id = R.drawable.ic_left),
-                contentDescription = "뒤로가기",
-                tint = ByeBooTheme.colors.white,
+        item {
+            Row(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(top = screenHeightDp(67.dp))
+                    .padding(horizontal = screenWidthDp(24.dp)),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_left),
+                    contentDescription = "뒤로가기",
+                    tint = ByeBooTheme.colors.white,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .noRippleClickable { onBackClick() })
+            }
+            Spacer(modifier = Modifier.height(screenHeightDp(42.dp)))
+        }
+
+        item {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                GuideContent(
+                    userName = uiState.nickname,
+                    guideText = "님의 상황에 꼭 맞춘\n${uiState.journeyName} 여정의 퀘스트 30개를 드릴게요.\n\n제가 드리는 퀘스트와 함께\n이별을 극복해 나가요!"
+                )
+            }
+
+            Spacer(modifier = Modifier.height(screenHeightDp(72.dp)))
+
+            ByeBooButton(
+                onClick = onStartClick,
+                buttonText = "시작하기",
+                buttonStyle = ByeBooTheme.typography.body2,
+                buttonTextColor = ByeBooTheme.colors.white,
+                buttonBackgroundColor = ByeBooTheme.colors.primary300,
                 modifier = Modifier
-                    .size(24.dp)
-                    .noRippleClickable { onBackClick() }
+                    .padding(horizontal = screenWidthDp(24.dp))
+                    .padding(bottom = padding + 10.dp)
             )
         }
-
-        Spacer(modifier = Modifier.height(screenHeightDp(42.dp)))
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-        ) {
-            GuideContent(
-                userName = uiState.nickname,
-                guideText = "님의 상황에 꼭 맞춘\n${uiState.journeyName} 여정의 퀘스트 30개를 드릴게요.\n\n제가 드리는 퀘스트와 함께\n이별을 극복해 나가요!"
-            )
-        }
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        ByeBooButton(
-            onClick = onStartClick,
-            buttonText = "시작하기",
-            buttonStyle = ByeBooTheme.typography.body2,
-            buttonTextColor = ByeBooTheme.colors.white,
-            buttonBackgroundColor = ByeBooTheme.colors.primary300,
-            modifier = Modifier
-                .padding(horizontal = screenWidthDp(24.dp))
-                .padding(bottom = padding + 10.dp)
-        )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@
 compileSdk = "35"
 minSdk = "28"
 targetSdk = "35"
-versionCode = "1"
-versionName = "1.0"
+versionCode = "2"
+versionName = "1.0.1"
 
 # Kotlin
 agp = "8.9.2"


### PR DESCRIPTION
## Related issue 🛠
- closed #215

## Work Description 📝
- LazyColumn으로 변경

## Screenshot 📸
https://github.com/user-attachments/assets/85968d7a-61ee-47a0-86be-758865b6b36c

## Uncompleted Tasks 😅
N/A

## PR Point 📌

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * 퀘스트 시작 화면의 스크롤 구조를 개선해 긴 콘텐츠에서 더 부드럽게 동작합니다.
  * 하단 실행 버튼 배치를 정리해 터치 영역과 여백이 더 일관되게 표시됩니다.
  * 전반적인 레이아웃 간격을 다듬어 가독성을 향상했습니다.
* Chores
  * 앱 버전을 1.0.1로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->