### PR TITLE
[fix/#218] 회원가입 버튼 중복 클릭 시 API 중복 호출 문제 수정

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoViewModel.kt
@@ -34,6 +34,8 @@ class UserInfoViewModel @Inject constructor(
     private val _sideEffect = MutableSharedFlow<UserInfoSideEffect>()
     val sideEffect: SharedFlow<UserInfoSideEffect> = _sideEffect.asSharedFlow()
 
+    private var hasSubmitted = false
+
     companion object {
         private const val MAX_NICKNAME_LENGTH = 5
     }
@@ -93,8 +95,14 @@ class UserInfoViewModel @Inject constructor(
     }
 
     fun finishUserInfo() {
+        if (hasSubmitted) return
+        hasSubmitted = true
+
         viewModelScope.launch {
-            if (_uiState.value.nicknameValidation != NicknameValidationResult.Valid) return@launch
+            if (_uiState.value.nicknameValidation != NicknameValidationResult.Valid) {
+                hasSubmitted = false
+                return@launch
+            }
 
             val userInfo = UserInfoModel(
                 name = _uiState.value.nickname,
@@ -112,6 +120,7 @@ class UserInfoViewModel @Inject constructor(
                 }
                 _sideEffect.emit(UserInfoSideEffect.NavigateToLoading)
             } else {
+                hasSubmitted = false
                 _sideEffect.emit(UserInfoSideEffect.ShowSnackBar("서버에 연결할 수 없습니다. 잠시 후 시도해 주세요."))
             }
         }


### PR DESCRIPTION
## Related issue 🛠
- closed #218 

## Work Description 📝
- 회원가입 화면에서 "다음으로" 버튼을 여러 번 누를 경우, API가 중복으로 호출되는 문제를 수정했습니다.
- ViewModel 내에 `hasSubmitted` 플래그를 추가하여 중복 호출을 방지했습니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- N/A

## PR Point 📌

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자 정보 제출 시 중복 제출 방지 기능 추가
  * 검증 실패 시 폼 재제출 가능하도록 개선
  * 서버 오류 발생 시 폼 재제출 가능하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->