### PR TITLE
[Feat/#222] 마이페이지 알림 UI 구현

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -391,24 +391,3 @@ private fun MyPageScreen(
         }
     }
 }
-
-@Preview
-@Composable
-private fun MyPageScreenPreview() {
-    ByeBooTheme {
-        MyPageScreen(
-            uiState = MyPageState(),
-            bottomPadding = 0.dp,
-            onNicknameChangeClick = {},
-            onCompletedJourneyClick = {},
-            onGoToByeBooUniverseClick = {},
-            onAskingByeBooClick = {},
-            onServiceWithByeBooClick = {},
-            onPrivacyPolicyClick = {},
-            onTermsOfServiceClick = {},
-            onLogoutClick = {},
-            onDeleteAccountClick = {},
-
-            )
-    }
-}

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -22,6 +22,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +33,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
@@ -41,6 +45,7 @@ import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.openUrl
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.mypage.component.MyPageModal
+import com.byeboo.app.presentation.mypage.component.MyPageNotification
 
 @Composable
 fun MyPageRoute(
@@ -129,6 +134,8 @@ private fun MyPageScreen(
     onDeleteAccountClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var isChecked by remember { mutableStateOf(false) }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -314,6 +321,23 @@ private fun MyPageScreen(
             Spacer(modifier = Modifier.height(48.dp))
 
             Text(
+                text = "알림",
+                style = ByeBooTheme.typography.body1,
+                color = ByeBooTheme.colors.gray400
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            MyPageNotification(
+                isEnabledAlarm = isChecked,
+                onCheckedClick = {
+                    isChecked = !isChecked
+                }
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Text(
                 text = "약관 및 정책",
                 style = ByeBooTheme.typography.body1,
                 color = ByeBooTheme.colors.gray400
@@ -365,5 +389,26 @@ private fun MyPageScreen(
 
             Spacer(modifier = Modifier.height(38.dp))
         }
+    }
+}
+
+@Preview
+@Composable
+private fun MyPageScreenPreview() {
+    ByeBooTheme {
+        MyPageScreen(
+            uiState = MyPageState(),
+            bottomPadding = 0.dp,
+            onNicknameChangeClick = {},
+            onCompletedJourneyClick = {},
+            onGoToByeBooUniverseClick = {},
+            onAskingByeBooClick = {},
+            onServiceWithByeBooClick = {},
+            onPrivacyPolicyClick = {},
+            onTermsOfServiceClick = {},
+            onLogoutClick = {},
+            onDeleteAccountClick = {},
+
+            )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/component/MypageNotification.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/component/MypageNotification.kt
@@ -1,0 +1,46 @@
+package com.byeboo.app.presentation.mypage.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import com.byeboo.app.R
+import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import com.byeboo.app.core.util.noRippleClickable
+
+@Composable
+fun MyPageNotification(
+    modifier: Modifier = Modifier,
+    isEnabledAlarm: Boolean = false,
+    onCheckedClick: (Boolean) -> Unit
+) {
+    val toggle = if (isEnabledAlarm) R.drawable.ic_toggle_on else R.drawable.ic_toggle_off
+    Row(
+        modifier = modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "퀘스트 오픈 알림",
+            style = ByeBooTheme.typography.body3,
+            color = ByeBooTheme.colors.gray50,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Image(
+            imageVector = ImageVector.vectorResource(toggle),
+            contentDescription = "alarm toggle",
+            modifier = Modifier
+                .noRippleClickable(
+                    onClick = { onCheckedClick(!isEnabledAlarm) }
+                )
+        )
+    }
+}

--- a/app/src/main/res/drawable/ic_toggle_off.xml
+++ b/app/src/main/res/drawable/ic_toggle_off.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="28dp"
+    android:viewportWidth="48"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M14,0L34,0A14,14 0,0 1,48 14L48,14A14,14 0,0 1,34 28L14,28A14,14 0,0 1,0 14L0,14A14,14 0,0 1,14 0z"
+      android:fillColor="#6E6E6E"/>
+  <path
+      android:pathData="M14,2L14,2A12,12 0,0 1,26 14L26,14A12,12 0,0 1,14 26L14,26A12,12 0,0 1,2 14L2,14A12,12 0,0 1,14 2z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/drawable/ic_toggle_on.xml
+++ b/app/src/main/res/drawable/ic_toggle_on.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="28dp"
+    android:viewportWidth="48"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M14,0L34,0A14,14 0,0 1,48 14L48,14A14,14 0,0 1,34 28L14,28A14,14 0,0 1,0 14L0,14A14,14 0,0 1,14 0z"
+      android:fillColor="#A16DFF"/>
+  <path
+      android:pathData="M34,2L34,2A12,12 0,0 1,46 14L46,14A12,12 0,0 1,34 26L34,26A12,12 0,0 1,22 14L22,14A12,12 0,0 1,34 2z"
+      android:fillColor="#ffffff"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #222 

## Work Description 📝
- 마이페이지 알림 항목 UI 추가했습니다

## Screenshot 📸

https://github.com/user-attachments/assets/9e09a569-a1aa-499f-b435-84bd8cdda701


## Uncompleted Tasks 😅
- N/A

## PR Point 📌
지금은 토글 온오프할 때 이미지만 스위치 되게 했는데 조금 부자연스럽게 스위칭 되는 느낌이 있습니다...
토글 자체를 만들어서 애니메이션을 넣어야 할지 지금처럼 갈지 의견 부탁드립니다 ~

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이 페이지에 알림 토글이 추가되었습니다.
  * 사용자가 ‘퀘스트 오픈 알림’을 켜고 끌 수 있습니다.
  * 토글 상태에 따라 새로운 온/오프 아이콘이 적용되어 시각적으로 상태가 구분됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->