### PR TITLE
[mod/#251] 화면 내 상단 패딩 변경

### DIFF
--- a/app/src/main/java/com/byeboo/app/presentation/auth/navigation/AuthNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/navigation/AuthNavigation.kt
@@ -1,6 +1,6 @@
 package com.byeboo.app.presentation.auth.navigation
 
-import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -22,12 +22,12 @@ fun NavController.navigateToLoading(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.authGraph(
     navigateToLoading: () -> Unit,
     navigateToHomeAmulet: () -> Unit,
-    padding: Dp
+    paddingValues: PaddingValues
 ) {
     composable<UserInfo> {
         UserInfoRoute(
             navigateToLoading = navigateToLoading,
-            padding = padding
+            paddingValues = paddingValues
         )
     }
     composable<Loading> {

--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoScreen.kt
@@ -155,7 +155,7 @@ private fun UserInfoScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = screenWidthDp(24.dp))
-                .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp))
+                .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp))
         ) {
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/auth/userinfo/UserInfoScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,7 +29,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -55,7 +55,7 @@ import kotlinx.coroutines.launch
 fun UserInfoRoute(
     navigateToLoading: () -> Unit,
     modifier: Modifier = Modifier,
-    padding: Dp,
+    paddingValues: PaddingValues,
     viewModel: UserInfoViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -88,7 +88,7 @@ fun UserInfoRoute(
         onResetQuest = viewModel::resetQuest,
         onSubmit = viewModel::finishUserInfo,
         modifier = modifier,
-        padding = padding
+        paddingValues = paddingValues,
     )
 }
 
@@ -106,8 +106,8 @@ private fun UserInfoScreen(
     onResetEmotion: () -> Unit,
     onResetQuest: () -> Unit,
     onSubmit: () -> Unit,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
-    padding: Dp
 ) {
     val coroutineScope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
@@ -155,9 +155,8 @@ private fun UserInfoScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = screenWidthDp(24.dp))
+                .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp))
         ) {
-            Spacer(modifier = Modifier.padding(top = screenHeightDp(67.dp)))
-
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -211,7 +210,7 @@ private fun UserInfoScreen(
 
             ByeBooActivationButton(
                 modifier = Modifier
-                    .padding(bottom = padding + screenHeightDp(10.dp)),
+                    .padding(bottom = paddingValues.calculateBottomPadding() + screenHeightDp(10.dp)),
                 buttonDisableColor = ByeBooTheme.colors.blackAlpha50,
                 buttonDisableTextColor = ByeBooTheme.colors.gray400,
                 isEnabled = isStepValid,

--- a/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -35,7 +36,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -67,7 +67,7 @@ fun HomeRoute(
     navigateToTutorial: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     navigateToOffboardingNewJourney: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -106,7 +106,7 @@ fun HomeRoute(
         onClickQuest = viewModel::onClickQuest,
         onClickQuestStart = viewModel::onClickQuestStart,
         onHelpIconClick = viewModel::onHelpIconClicked,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onOffboardingNewJourneyClick = viewModel::onOffboardingNewJourneyClicked,
         onLottieClick = viewModel::onLottieClicked
     )
@@ -118,7 +118,7 @@ private fun HomeScreen(
     onClickQuest: () -> Unit,
     onClickQuestStart: () -> Unit,
     onHelpIconClick: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onOffboardingNewJourneyClick: () -> Unit,
     onLottieClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -181,7 +181,7 @@ private fun HomeScreen(
                     modifier = modifier
                         .fillMaxSize()
                         .padding(horizontal = screenWidthDp(24.dp))
-                        .padding(top = screenHeightDp(67.dp))
+                        .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp))
                 ) {
                     when (uiState.status) {
                         HomeStatus.INITIAL_START -> {
@@ -273,7 +273,7 @@ private fun HomeScreen(
                         .align(Alignment.BottomCenter)
                         .fillMaxWidth()
                         .padding(horizontal = screenWidthDp(24.dp))
-                        .padding(bottom = maxOf(bottomPadding - screenHeightDp(20.dp), 0.dp))
+                        .padding(bottom = maxOf(paddingValues.calculateBottomPadding() - screenHeightDp(20.dp), 0.dp))
                 ) {
                     // 하단 말풍선
                     Box(

--- a/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/HomeScreen.kt
@@ -181,7 +181,7 @@ private fun HomeScreen(
                     modifier = modifier
                         .fillMaxSize()
                         .padding(horizontal = screenWidthDp(24.dp))
-                        .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp))
+                        .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp))
                 ) {
                     when (uiState.status) {
                         HomeStatus.INITIAL_START -> {

--- a/app/src/main/java/com/byeboo/app/presentation/home/homeonboarding/HomeOnboardingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/homeonboarding/HomeOnboardingScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,7 +26,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -44,7 +44,7 @@ import com.byeboo.app.presentation.home.component.SpeechBubbleWithText
 @Composable
 fun HomeOnboardingRoute(
     navigateToHome: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     viewModel: HomeOnboardingViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -61,7 +61,7 @@ fun HomeOnboardingRoute(
     HomeOnboardingScreen(
         uiState = uiState,
         onHomeClick = viewModel::onHomeLongClick,
-        bottomPadding = bottomPadding
+        paddingValues = paddingValues,
     )
 }
 
@@ -69,7 +69,7 @@ fun HomeOnboardingRoute(
 private fun HomeOnboardingScreen(
     uiState: HomeOnboardingUiState,
     onHomeClick: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier
 ) {
     val haptic = LocalHapticFeedback.current
@@ -155,7 +155,7 @@ private fun HomeOnboardingScreen(
                     progress = { progress },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = screenHeightDp(89.dp) + bottomPadding)
+                        .padding(bottom = screenHeightDp(89.dp) + paddingValues.calculateBottomPadding())
                         .then(clickableModifier)
                         .aspectRatio(1f)
                 )

--- a/app/src/main/java/com/byeboo/app/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/home/navigation/HomeNavigation.kt
@@ -1,6 +1,6 @@
 package com.byeboo.app.presentation.home.navigation
 
-import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -34,7 +34,7 @@ fun NavGraphBuilder.homeGraph(
     navigateToOffboardingNewJourney: () -> Unit,
     navigateToHome: () -> Unit,
     navigateToHomeOnboarding: () -> Unit,
-    padding: Dp
+    paddingValues: PaddingValues
 ) {
     composable<Home> {
         HomeRoute(
@@ -43,14 +43,14 @@ fun NavGraphBuilder.homeGraph(
             navigateToTutorial = navigateToTutorial,
             navigateToOffboardingCompletedGuide = navigateToOffboardingCompletedGuide,
             navigateToOffboardingNewJourney = navigateToOffboardingNewJourney,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
     composable<HomeOnboarding> {
         ByeBooBackHandler()
         HomeOnboardingRoute(
             navigateToHome = navigateToHome,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
     composable<HomeAmulet> {

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -2,6 +2,7 @@ package com.byeboo.app.presentation.main
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -19,7 +20,7 @@ import com.byeboo.app.presentation.tutorial.navigation.tutorialGraph
 @Composable
 fun MainNavHost(
     navigator: MainNavigator,
-    padding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier
 ) {
     val clearStackNavOptions = navOptions {
@@ -53,13 +54,13 @@ fun MainNavHost(
             navigateToHome = { navigator.navigateToHome(clearStackNavOptions) },
             navigateToUserInfo = { navigator.navigateToUserInfo(clearStackNavOptions) },
             navigateToTermsOfService = { navigator.navigateToTerms(clearStackNavOptions) },
-            padding = padding
+            paddingValues = paddingValues
         )
 
         authGraph(
             navigateToLoading = { navigator.navigateToLoading(clearStackNavOptions) },
             navigateToHomeAmulet = { navigator.navigateToHomeAmulet(clearStackNavOptions) },
-            padding = padding
+            paddingValues = paddingValues
         )
 
         homeGraph(
@@ -83,7 +84,7 @@ fun MainNavHost(
             },
             navigateToHome = { navigator.navigateToHome(clearStackNavOptions) },
             navigateToHomeOnboarding = { navigator.navigateToHomeOnboarding(clearStackNavOptions) },
-            padding = padding
+            paddingValues = paddingValues
 
         )
 
@@ -132,7 +133,7 @@ fun MainNavHost(
                 )
             },
             navigateUp = navigator::navigateUp,
-            padding = padding
+            paddingValues = paddingValues
         )
 
         myPageGraph(
@@ -145,7 +146,7 @@ fun MainNavHost(
             navigateToTutorial = { navigator.navigateToTutorial(keepStackNavOptions) },
             navigateToMyPage = { navigator.navigateToMyPage(clearStackNavOptions) },
             navigateToSplash = { navigator.navigateToSplash(clearStackNavOptions) },
-            padding = padding
+            paddingValues = paddingValues
         )
 
         offboardingGraph(
@@ -174,12 +175,12 @@ fun MainNavHost(
                     keepStackNavOptions
                 )
             },
-            padding = padding
+            paddingValues = paddingValues
         )
 
         tutorialGraph(
             navigateToUp = navigator::navigateUp,
-            padding = padding
+            paddingValues = paddingValues
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
@@ -156,10 +156,10 @@ fun MainScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .background(ByeBooTheme.colors.black)
-        ) {
+        ) { paddingValues ->
             MainNavHost(
                 navigator = navigator,
-                padding = it.calculateBottomPadding(),
+                paddingValues = paddingValues,
                 modifier = Modifier
             )
         }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -224,7 +224,7 @@ private fun MyPageScreen(
                 .fillMaxWidth()
                 .background(ByeBooTheme.colors.black)
                 .padding(horizontal = screenWidthDp(24.dp))
-                .padding(top = screenHeightDp(27.dp), bottom = screenHeightDp(16.dp))
+                .padding(top = screenHeightDp(43.dp), bottom = screenHeightDp(16.dp))
         )
 
         LazyColumn(

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -211,7 +211,7 @@ private fun MyPageScreen(
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding(),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {
@@ -223,7 +223,8 @@ private fun MyPageScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(ByeBooTheme.colors.black)
-                .padding(horizontal = screenWidthDp(24.dp), vertical = screenHeightDp(16.dp))
+                .padding(horizontal = screenWidthDp(24.dp))
+                .padding(top = screenHeightDp(27.dp), bottom = screenHeightDp(16.dp))
         )
 
         LazyColumn(

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,9 +21,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -38,7 +38,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -63,7 +62,7 @@ fun MyPageRoute(
     navigateToOffboardingCompletedJourney: () -> Unit,
     navigateToTutorial: () -> Unit,
     navigateToSplash: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
@@ -144,12 +143,14 @@ fun MyPageRoute(
                         permissionLauncher.launch(POST_NOTIFICATIONS)
                     }
                 }
+
                 is MyPageSideEffect.NavigateToSetting -> {
                     val intent = Intent(Settings.ACTION_ALL_APPS_NOTIFICATION_SETTINGS).apply {
                         putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
                     }
                     context.startActivity(intent)
                 }
+
                 is MyPageSideEffect.OpenUrl -> openUrl(context = context, effect.url)
                 is MyPageSideEffect.NavigateToEditProfile -> navigateToEditProfile()
                 is MyPageSideEffect.NavigateToOffboardingCompletedJourney -> navigateToOffboardingCompletedJourney()
@@ -174,7 +175,7 @@ fun MyPageRoute(
 
     MyPageScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onNicknameChangeClick = viewModel::onNicknameChangeClicked,
         onCompletedJourneyClick = viewModel::onCompletedJourneyClicked,
         onGoToByeBooUniverseClick = viewModel::onGoToByeBooUniverseClicked,
@@ -192,7 +193,7 @@ fun MyPageRoute(
 @Composable
 private fun MyPageScreen(
     uiState: MyPageState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onNicknameChangeClick: () -> Unit,
     onCompletedJourneyClick: () -> Unit,
     onGoToByeBooUniverseClick: () -> Unit,
@@ -209,8 +210,10 @@ private fun MyPageScreen(
         modifier = modifier
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = screenHeightDp(67.dp), bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
         Text(
             text = "내 정보",
@@ -220,241 +223,267 @@ private fun MyPageScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(ByeBooTheme.colors.black)
-                .padding(vertical = screenHeightDp(16.dp))
+                .padding(horizontal = screenWidthDp(24.dp), vertical = screenHeightDp(16.dp))
         )
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(
+                start = screenWidthDp(24.dp),
+                top = screenHeightDp(8.dp),
+                end = screenWidthDp(24.dp),
+                bottom = screenHeightDp(34.dp)
+            )
         ) {
-            Spacer(modifier = Modifier.height(screenHeightDp(8.dp)))
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color = ByeBooTheme.colors.whiteAlpha10)
+                        .clickable(onClick = onNicknameChangeClick)
+                        .padding(
+                            horizontal = screenWidthDp(24.dp),
+                            vertical = screenHeightDp(18.5.dp)
+                        )
+                ) {
+                    Text(
+                        text = uiState.nickname,
+                        style = ByeBooTheme.typography.body3,
+                        color = ByeBooTheme.colors.gray300
+                    )
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(color = ByeBooTheme.colors.whiteAlpha10)
-                    .clickable(onClick = onNicknameChangeClick)
-                    .padding(horizontal = screenWidthDp(24.dp), vertical = screenHeightDp(18.5.dp))
-            ) {
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_right),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = ByeBooTheme.colors.gray50
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(screenHeightDp(8.dp)))
+            }
+
+            item {
+                HorizontalDivider(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = screenHeightDp(8.dp)),
+                    thickness = 1.dp,
+                    color = ByeBooTheme.colors.whiteAlpha10
+                )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_tip_write),
+                        contentDescription = null,
+                        tint = Color.Unspecified
+                    )
+
+                    Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
+
+                    Text(
+                        text = "나의 기록",
+                        style = ByeBooTheme.typography.body1,
+                        color = ByeBooTheme.colors.gray300
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(screenHeightDp(12.dp)))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color = ByeBooTheme.colors.whiteAlpha10)
+                        .border(
+                            width = 1.dp,
+                            color = ByeBooTheme.colors.primary300,
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        .clickable(onClick = onCompletedJourneyClick)
+                        .padding(
+                            horizontal = screenWidthDp(24.dp),
+                            vertical = screenHeightDp(20.dp)
+                        )
+                ) {
+                    Text(
+                        text = "완료한 여정 돌아보기",
+                        style = ByeBooTheme.typography.body2,
+                        color = ByeBooTheme.colors.gray50
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_change),
+                        contentDescription = null,
+                        tint = Color.Unspecified
+                    )
+
+                    Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
+
+                    Text(
+                        text = "보리가 궁금하다면?",
+                        style = ByeBooTheme.typography.body1,
+                        color = ByeBooTheme.colors.gray300
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(screenHeightDp(12.dp)))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color = ByeBooTheme.colors.whiteAlpha10)
+                        .border(
+                            width = 1.dp,
+                            color = ByeBooTheme.colors.primary300,
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        .clickable(onClick = onGoToByeBooUniverseClick)
+                        .padding(
+                            horizontal = screenWidthDp(24.dp),
+                            vertical = screenHeightDp(20.dp)
+                        )
+                ) {
+                    Text(
+                        text = "Bye Boo 세계관 보러 가기",
+                        style = ByeBooTheme.typography.body2,
+                        color = ByeBooTheme.colors.gray50
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
+            }
+
+            item {
+                HorizontalDivider(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = screenHeightDp(8.dp)),
+                    thickness = 1.dp,
+                    color = ByeBooTheme.colors.whiteAlpha10
+                )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
+
                 Text(
-                    text = uiState.nickname,
+                    text = "문의하기",
+                    style = ByeBooTheme.typography.body1,
+                    color = ByeBooTheme.colors.gray400
+                )
+
+                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+
+                Text(
+                    text = "바이부에 문의하기",
                     style = ByeBooTheme.typography.body3,
-                    color = ByeBooTheme.colors.gray300
+                    color = ByeBooTheme.colors.gray50,
+                    modifier = Modifier.clickable(onClick = onAskingByeBooClick)
                 )
 
-                Spacer(modifier = Modifier.weight(1f))
-
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_right),
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = ByeBooTheme.colors.gray50
-                )
-            }
-            Spacer(modifier = Modifier.height(screenHeightDp(8.dp)))
-
-            HorizontalDivider(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = screenHeightDp(8.dp)),
-                thickness = 1.dp,
-                color = ByeBooTheme.colors.whiteAlpha10
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Start,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_tip_write),
-                    contentDescription = null,
-                    tint = Color.Unspecified
-                )
-
-                Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
+                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
 
                 Text(
-                    text = "나의 기록",
+                    text = "바이부와 함께 서비스 만들기",
+                    style = ByeBooTheme.typography.body3,
+                    color = ByeBooTheme.colors.gray50,
+                    modifier = Modifier.clickable(onClick = onServiceWithByeBooClick)
+                )
+
+                Spacer(modifier = Modifier.height(screenHeightDp(48.dp)))
+            }
+
+            item {
+                Text(
+                    text = "알림",
                     style = ByeBooTheme.typography.body1,
-                    color = ByeBooTheme.colors.gray300
+                    color = ByeBooTheme.colors.gray400
                 )
+
+                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+
+                MyPageNotification(
+                    isEnabledAlarm = uiState.isAlarmEnabled,
+                    onCheckedClick = { onAlarmToggleClick() }
+                )
+
+                Spacer(modifier = Modifier.height(screenHeightDp(48.dp)))
             }
 
-            Spacer(modifier = Modifier.height(screenHeightDp(12.dp)))
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(color = ByeBooTheme.colors.whiteAlpha10)
-                    .border(
-                        width = 1.dp,
-                        color = ByeBooTheme.colors.primary300,
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                    .clickable(onClick = onCompletedJourneyClick)
-                    .padding(horizontal = screenWidthDp(24.dp), vertical = screenHeightDp(20.dp))
-            ) {
+            item {
                 Text(
-                    text = "완료한 여정 돌아보기",
-                    style = ByeBooTheme.typography.body2,
-                    color = ByeBooTheme.colors.gray50
-                )
-            }
-
-            Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Start,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_change),
-                    contentDescription = null,
-                    tint = Color.Unspecified
-                )
-
-                Spacer(modifier = Modifier.width(screenWidthDp(8.dp)))
-
-                Text(
-                    text = "보리가 궁금하다면?",
+                    text = "약관 및 정책",
                     style = ByeBooTheme.typography.body1,
-                    color = ByeBooTheme.colors.gray300
+                    color = ByeBooTheme.colors.gray400
                 )
-            }
 
-            Spacer(modifier = Modifier.height(screenHeightDp(12.dp)))
+                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
 
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(color = ByeBooTheme.colors.whiteAlpha10)
-                    .border(
-                        width = 1.dp,
-                        color = ByeBooTheme.colors.primary300,
-                        shape = RoundedCornerShape(12.dp)
-                    )
-                    .clickable(onClick = onGoToByeBooUniverseClick)
-                    .padding(horizontal = screenWidthDp(24.dp), vertical = screenHeightDp(20.dp))
-            ) {
                 Text(
-                    text = "Bye Boo 세계관 보러 가기",
-                    style = ByeBooTheme.typography.body2,
-                    color = ByeBooTheme.colors.gray50
+                    text = "개인정보 처리 방침",
+                    style = ByeBooTheme.typography.body3,
+                    color = ByeBooTheme.colors.gray50,
+                    modifier = Modifier.clickable(onClick = onPrivacyPolicyClick)
                 )
+
+                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+
+                Text(
+                    text = "서비스 이용 약관",
+                    style = ByeBooTheme.typography.body3,
+                    color = ByeBooTheme.colors.gray50,
+                    modifier = Modifier.clickable(onClick = onTermsOfServiceClick)
+                )
+
+                Spacer(modifier = Modifier.height(screenHeightDp(48.dp)))
             }
 
-            Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
+            item {
+                Text(
+                    text = "계정",
+                    style = ByeBooTheme.typography.body1,
+                    color = ByeBooTheme.colors.gray400
+                )
 
-            HorizontalDivider(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = screenHeightDp(8.dp)),
-                thickness = 1.dp,
-                color = ByeBooTheme.colors.whiteAlpha10
-            )
+                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
 
-            Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
+                Text(
+                    text = "로그아웃",
+                    style = ByeBooTheme.typography.body3,
+                    color = ByeBooTheme.colors.gray50,
+                    modifier = Modifier.clickable(onClick = onLogoutClick)
+                )
 
-            Text(
-                text = "문의하기",
-                style = ByeBooTheme.typography.body1,
-                color = ByeBooTheme.colors.gray400
-            )
+                Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
 
-            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-
-            Text(
-                text = "바이부에 문의하기",
-                style = ByeBooTheme.typography.body3,
-                color = ByeBooTheme.colors.gray50,
-                modifier = Modifier.clickable(onClick = onAskingByeBooClick)
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-
-            Text(
-                text = "바이부와 함께 서비스 만들기",
-                style = ByeBooTheme.typography.body3,
-                color = ByeBooTheme.colors.gray50,
-                modifier = Modifier.clickable(onClick = onServiceWithByeBooClick)
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(48.dp)))
-
-            Text(
-                text = "알림",
-                style = ByeBooTheme.typography.body1,
-                color = ByeBooTheme.colors.gray400
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-
-            MyPageNotification(
-                isEnabledAlarm = uiState.isAlarmEnabled,
-                onCheckedClick = { onAlarmToggleClick() }
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(48.dp)))
-
-            Text(
-                text = "약관 및 정책",
-                style = ByeBooTheme.typography.body1,
-                color = ByeBooTheme.colors.gray400
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-
-            Text(
-                text = "개인정보 처리 방침",
-                style = ByeBooTheme.typography.body3,
-                color = ByeBooTheme.colors.gray50,
-                modifier = Modifier.clickable(onClick = onPrivacyPolicyClick)
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-
-            Text(
-                text = "서비스 이용 약관",
-                style = ByeBooTheme.typography.body3,
-                color = ByeBooTheme.colors.gray50,
-                modifier = Modifier.clickable(onClick = onTermsOfServiceClick)
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(48.dp)))
-
-            Text(
-                text = "계정",
-                style = ByeBooTheme.typography.body1,
-                color = ByeBooTheme.colors.gray400
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-
-            Text(
-                text = "로그아웃",
-                style = ByeBooTheme.typography.body3,
-                color = ByeBooTheme.colors.gray50,
-                modifier = Modifier.clickable(onClick = onLogoutClick)
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-
-            Text(
-                text = "탈퇴",
-                style = ByeBooTheme.typography.body3,
-                color = ByeBooTheme.colors.gray50,
-                modifier = Modifier.clickable(onClick = onDeleteAccountClick)
-            )
-
-            Spacer(modifier = Modifier.height(screenHeightDp(38.dp)))
+                Text(
+                    text = "탈퇴",
+                    style = ByeBooTheme.typography.body3,
+                    color = ByeBooTheme.colors.gray50,
+                    modifier = Modifier.clickable(onClick = onDeleteAccountClick)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
@@ -102,7 +102,7 @@ private fun EditProfileScreen(
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = screenHeightDp(paddingValues.calculateBottomPadding() + 10.dp)
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
@@ -2,6 +2,7 @@ package com.byeboo.app.presentation.mypage.editprofile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -45,7 +46,7 @@ import kotlinx.coroutines.delay
 @Composable
 fun EditProfileRoute(
     navigateToMyPage: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     viewModel: EditProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -70,7 +71,7 @@ fun EditProfileRoute(
 
     EditProfileScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onBackClick = viewModel::onBackClicked,
         onNicknameChange = viewModel::updateNickname,
         onClearClick = { viewModel.updateNickname("") },
@@ -82,7 +83,7 @@ fun EditProfileRoute(
 @Composable
 private fun EditProfileScreen(
     uiState: EditProfileState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onBackClick: () -> Unit,
     onNicknameChange: (String) -> Unit,
     onClearClick: () -> Unit,
@@ -100,7 +101,10 @@ private fun EditProfileScreen(
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = screenHeightDp(67.dp), bottom = screenHeightDp(bottomPadding + 10.dp))
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = screenHeightDp(paddingValues.calculateBottomPadding() + 10.dp)
+            )
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/editprofile/EditProfileScreen.kt
@@ -103,7 +103,7 @@ private fun EditProfileScreen(
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(
                 top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
-                bottom = screenHeightDp(paddingValues.calculateBottomPadding() + 10.dp)
+                bottom = screenHeightDp(paddingValues.calculateBottomPadding() + screenHeightDp(10.dp))
             )
     ) {
         Row(

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/navigation/MypageNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/navigation/MypageNavigation.kt
@@ -1,6 +1,6 @@
 package com.byeboo.app.presentation.mypage.navigation
 
-import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -25,7 +25,7 @@ fun NavGraphBuilder.myPageGraph(
     navigateToTutorial: () -> Unit,
     navigateToSplash: () -> Unit,
     navigateToMyPage: () -> Unit,
-    padding: Dp
+    paddingValues: PaddingValues
 ) {
     composable<MyPage> {
         MyPageRoute(
@@ -33,14 +33,14 @@ fun NavGraphBuilder.myPageGraph(
             navigateToOffboardingCompletedJourney = navigateToOffboardingCompletedJourney,
             navigateToTutorial = navigateToTutorial,
             navigateToSplash = navigateToSplash,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 
     composable<EditProfile> {
         EditProfileRoute(
             navigateToMyPage = navigateToMyPage,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
@@ -1,6 +1,6 @@
 package com.byeboo.app.presentation.offboarding.navigation
 
-import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -41,14 +41,14 @@ fun NavGraphBuilder.offboardingGraph(
     navigateToQuestReview: (Long) -> Unit,
     navigateUp: () -> Unit,
     navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
-    padding: Dp
+    paddingValues: PaddingValues
 ) {
     composable<OffboardingCompletedGuide> {
         OffboardingCompletedGuideRoute(
             navigateToHome = navigateToHome,
             navigateToOffboardingNewJourney = navigateToOffboardingNewJourney,
             navigateToOffboardingCompletedJourney = navigateToOffboardingCompletedJourney,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 
@@ -56,7 +56,7 @@ fun NavGraphBuilder.offboardingGraph(
         OffboardingNewJourneyRoute(
             navigateToQuestStart = navigateToQuestStart,
             navigateUp = navigateUp,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 
@@ -64,7 +64,7 @@ fun NavGraphBuilder.offboardingGraph(
         OffboardingCompletedJourneyRoute(
             navigateUp = navigateUp,
             navigateToOffboardingQuestCompleted = navigateToOffboardingQuestCompleted,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 
@@ -76,7 +76,7 @@ fun NavGraphBuilder.offboardingGraph(
             journey = journey,
             navigateUp = navigateUp,
             navigateToQuestReview = navigateToQuestReview,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedguide/OffboardingCompletedGuideScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedguide/OffboardingCompletedGuideScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -67,7 +68,7 @@ fun OffboardingCompletedGuideRoute(
     navigateToHome: () -> Unit,
     navigateToOffboardingNewJourney: () -> Unit,
     navigateToOffboardingCompletedJourney: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: OffboardingCompletedGuideViewModel = hiltViewModel()
 ) {
@@ -92,7 +93,7 @@ fun OffboardingCompletedGuideRoute(
 
     OffboardingCompleteGuideScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onCloseClick = viewModel::onCloseClicked,
         onNewJourneyClick = viewModel::onNewJourneyClicked,
         onCompletedJourneyClick = viewModel::onCompletedJourneyClicked,
@@ -104,7 +105,7 @@ fun OffboardingCompletedGuideRoute(
 @Composable
 private fun OffboardingCompleteGuideScreen(
     uiState: OffboardingCompletedGuideState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onCloseClick: () -> Unit,
     onNewJourneyClick: () -> Unit,
     onCompletedJourneyClick: () -> Unit,
@@ -137,7 +138,10 @@ private fun OffboardingCompleteGuideScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(horizontal = screenWidthDp(24.dp))
-                    .padding(top = screenHeightDp(67.dp), bottom = screenHeightDp( 10.dp) + bottomPadding),
+                    .padding(
+                        top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                        bottom = paddingValues.calculateBottomPadding() + screenHeightDp(10.dp)
+                    ),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Icon(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedguide/OffboardingCompletedGuideScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedguide/OffboardingCompletedGuideScreen.kt
@@ -139,7 +139,7 @@ private fun OffboardingCompleteGuideScreen(
                     .fillMaxSize()
                     .padding(horizontal = screenWidthDp(24.dp))
                     .padding(
-                        top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                        top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                         bottom = paddingValues.calculateBottomPadding() + screenHeightDp(10.dp)
                     ),
                 horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedjourney/OffboardingCompletedJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedjourney/OffboardingCompletedJourneyScreen.kt
@@ -87,7 +87,7 @@ private fun OffboardingCompletedJourneyScreen(
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
             .verticalScroll(rememberScrollState())

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedjourney/OffboardingCompletedJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingcompletedjourney/OffboardingCompletedJourneyScreen.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.presentation.offboarding.offboardingcompletedjourney
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -45,7 +45,7 @@ import com.byeboo.app.presentation.offboarding.component.JourneyCard
 fun OffboardingCompletedJourneyRoute(
     navigateUp: () -> Unit,
     navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: OffboardingJourneyViewModel = hiltViewModel()
 ) {
@@ -66,7 +66,7 @@ fun OffboardingCompletedJourneyRoute(
 
     OffboardingCompletedJourneyScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onBackClick = viewModel::onBackClicked,
         onJourneyCompletedCardClick = viewModel::onJourneyCompletedCardClicked,
         modifier = modifier
@@ -76,7 +76,7 @@ fun OffboardingCompletedJourneyRoute(
 @Composable
 private fun OffboardingCompletedJourneyScreen(
     uiState: OffboardingJourneyState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onBackClick: () -> Unit,
     onJourneyCompletedCardClick: (QuestType) -> Unit,
     modifier: Modifier = Modifier
@@ -86,7 +86,10 @@ private fun OffboardingCompletedJourneyScreen(
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = screenHeightDp(67.dp), bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
             .verticalScroll(rememberScrollState())
     ) {
         Icon(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingnewjourney/OffboardingNewJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingnewjourney/OffboardingNewJourneyScreen.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.presentation.offboarding.offboardingnewjourney
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,7 +28,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -45,7 +45,7 @@ import com.byeboo.app.presentation.offboarding.component.JourneyCard
 fun OffboardingNewJourneyRoute(
     navigateToQuestStart: (QuestType?) -> Unit,
     navigateUp: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: OffboardingJourneyViewModel = hiltViewModel(),
     offboardingNewJourneyViewModel: OffboardingNewJourneyViewModel = hiltViewModel()
@@ -65,7 +65,7 @@ fun OffboardingNewJourneyRoute(
 
     OffboardingNewJourneyScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onBackClick = offboardingNewJourneyViewModel::onBackClicked,
         onJourneyUncompletedCardClick = { type ->
             offboardingNewJourneyViewModel.postNewJourney(
@@ -79,7 +79,7 @@ fun OffboardingNewJourneyRoute(
 @Composable
 private fun OffboardingNewJourneyScreen(
     uiState: OffboardingJourneyState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onBackClick: () -> Unit,
     onJourneyUncompletedCardClick: (QuestType) -> Unit,
     modifier: Modifier = Modifier
@@ -89,7 +89,10 @@ private fun OffboardingNewJourneyScreen(
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = screenHeightDp(67.dp), bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
             .verticalScroll(rememberScrollState())
     ) {
         Icon(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingnewjourney/OffboardingNewJourneyScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingnewjourney/OffboardingNewJourneyScreen.kt
@@ -90,7 +90,7 @@ private fun OffboardingNewJourneyScreen(
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
             .verticalScroll(rememberScrollState())

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestcompleted/OffboardingQuestCompletedScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestcompleted/OffboardingQuestCompletedScreen.kt
@@ -42,7 +42,7 @@ fun OffboardingQuestCompletedRoute(
     journey: QuestType,
     navigateUp: () -> Unit,
     navigateToQuestReview: (Long) -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: OffboardingQuestCompletedViewModel = hiltViewModel()
 ) {
@@ -68,7 +68,7 @@ fun OffboardingQuestCompletedRoute(
     OffboardingQuestCompletedScreen(
         uiState = uiState,
         onCancelClick = viewModel::onCancelClicked,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onQuestClick = viewModel::onQuestClicked,
         modifier = modifier
     )
@@ -78,7 +78,7 @@ fun OffboardingQuestCompletedRoute(
 private fun OffboardingQuestCompletedScreen(
     uiState: QuestCompletedState,
     onCancelClick: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onQuestClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -87,7 +87,10 @@ private fun OffboardingQuestCompletedScreen(
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = screenHeightDp(67.dp), bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_cancel),
@@ -117,7 +120,7 @@ private fun OffboardingQuestCompletedScreen(
         )
 
         LazyColumn(
-            contentPadding = PaddingValues(bottom = screenHeightDp(37.dp)),
+            contentPadding = PaddingValues(bottom = screenHeightDp(21.dp)),
             modifier = Modifier.fillMaxWidth()
         ) {
             uiState.questGroups.forEachIndexed { stepIndex, group ->

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestcompleted/OffboardingQuestCompletedScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestcompleted/OffboardingQuestCompletedScreen.kt
@@ -88,7 +88,7 @@ private fun OffboardingQuestCompletedScreen(
             .background(ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/QuestScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/QuestScreen.kt
@@ -112,7 +112,7 @@ private fun QuestScreen(
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/QuestScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/QuestScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -44,7 +43,7 @@ fun QuestRoute(
     navigateToQuestBehavior: (Long) -> Unit,
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompleteGuide: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     viewModel: QuestViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -63,16 +62,9 @@ fun QuestRoute(
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
-                is QuestSideEffect.NavigateToQuestTip -> navigateToQuestTip(
-                    effect.questId,
-                    effect.questType
-                )
-                is QuestSideEffect.NavigateToQuestRecording -> navigateToQuestRecording(
-                    effect.questId
-                )
-                is QuestSideEffect.NavigateToQuestBehavior -> navigateToQuestBehavior(
-                    effect.questId
-                )
+                is QuestSideEffect.NavigateToQuestTip -> navigateToQuestTip(effect.questId, effect.questType)
+                is QuestSideEffect.NavigateToQuestRecording -> navigateToQuestRecording(effect.questId)
+                is QuestSideEffect.NavigateToQuestBehavior -> navigateToQuestBehavior(effect.questId)
                 is QuestSideEffect.NavigateToQuestReview -> navigateToQuestReview(effect.questId)
                 is QuestSideEffect.NavigateToOffboardingCompletedGuide -> navigateToOffboardingCompleteGuide()
                 is QuestSideEffect.ShowSnackBar -> showSnackBar(effect.message)
@@ -83,7 +75,7 @@ fun QuestRoute(
     QuestScreen(
         uiState = uiState,
         listState = listState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onQuestClick = viewModel::onQuestClick,
         onDismissModal = viewModel::onQuitDismissModal,
         onTipClick = viewModel::onTipClick,
@@ -95,7 +87,7 @@ fun QuestRoute(
 private fun QuestScreen(
     uiState: QuestUiState,
     listState: LazyListState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onQuestClick: (Long) -> Unit,
     onDismissModal: () -> Unit,
     onTipClick: () -> Unit,
@@ -119,10 +111,14 @@ private fun QuestScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = screenHeightDp(67.dp))
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = screenWidthDp(24.dp))) {
             MiddleTag(
                 middleTagType = MiddleTagType.QUEST_START_DAY,
                 text = uiState.progressPeriod.toString(),
@@ -143,7 +139,11 @@ private fun QuestScreen(
         LazyColumn(
             state = listState,
             verticalArrangement = Arrangement.spacedBy(screenHeightDp(20.dp)),
-            contentPadding = PaddingValues(bottom = screenHeightDp(bottomPadding + 37.dp)),
+            contentPadding = PaddingValues(
+                start = screenWidthDp(24.dp),
+                end = screenWidthDp(24.dp),
+                bottom = screenHeightDp(37.dp)
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .background(ByeBooTheme.colors.black)

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -32,7 +33,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -56,7 +56,7 @@ import com.byeboo.app.presentation.quest.component.text.CreatedText
 fun QuestBehaviorCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: QuestBehaviorCompleteViewModel = hiltViewModel()
 ) {
@@ -90,7 +90,7 @@ fun QuestBehaviorCompleteRoute(
 
     QuestBehaviorCompleteScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onCloseClick = viewModel::onCloseClicked,
         imageUri = imageUri,
         modifier = modifier
@@ -100,7 +100,7 @@ fun QuestBehaviorCompleteRoute(
 @Composable
 private fun QuestBehaviorCompleteScreen(
     uiState: QuestBehaviorCompleteState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onCloseClick: () -> Unit,
     imageUri: Uri?,
     modifier: Modifier = Modifier
@@ -109,13 +109,15 @@ private fun QuestBehaviorCompleteScreen(
         modifier = modifier
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(bottom = screenHeightDp(bottomPadding))
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
-        Spacer(modifier = modifier.height(screenHeightDp(67.dp)))
-
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = screenWidthDp(24.dp)),
             horizontalArrangement = Arrangement.End
         ) {
             Icon(
@@ -129,11 +131,16 @@ private fun QuestBehaviorCompleteScreen(
         Spacer(modifier = modifier.height(screenHeightDp(16.dp)))
 
         LazyColumn(
-            modifier = modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            contentPadding = PaddingValues(
+                top = screenHeightDp(8.dp),
+                bottom = screenHeightDp(24.dp),
+                start = screenWidthDp(24.dp),
+                end = screenWidthDp(24.dp)
+            )
         ) {
             item {
-                Spacer(modifier = modifier.height(screenHeightDp(8.dp)))
-
                 QuestCompleteCard(
                     modifier = modifier.fillMaxWidth()
                 )
@@ -275,8 +282,6 @@ private fun QuestBehaviorCompleteScreen(
                         emotionType = emotion
                     )
                 }
-
-                Spacer(modifier = modifier.height(screenHeightDp(24.dp)))
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorCompleteScreen.kt
@@ -110,7 +110,7 @@ private fun QuestBehaviorCompleteScreen(
             .fillMaxSize()
             .background(ByeBooTheme.colors.black)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
@@ -170,7 +170,7 @@ private fun QuestBehaviorWritingScreen(
             }
             .addFocusCleaner(focusManager)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/QuestBehaviorWritingScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -37,7 +38,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
@@ -70,7 +70,7 @@ fun QuestBehaviorWritingRoute(
     navigateToQuestBehaviorComplete: (Long) -> Unit,
     navigateToQuestReview: (Long) -> Unit,
     navigateUp: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: QuestBehaviorViewModel = hiltViewModel()
 ) {
@@ -113,7 +113,7 @@ fun QuestBehaviorWritingRoute(
 
     QuestBehaviorWritingScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onBackClick = viewModel::onBackClicked,
         onTipClick = viewModel::onTipClicked,
         onUpdateSelectedImage = viewModel::updateSelectedImage,
@@ -130,7 +130,7 @@ fun QuestBehaviorWritingRoute(
 @Composable
 private fun QuestBehaviorWritingScreen(
     uiState: QuestBehaviorState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onBackClick: () -> Unit,
     onTipClick: () -> Unit,
     onUpdateSelectedImage: (Uri?) -> Unit,
@@ -169,24 +169,29 @@ private fun QuestBehaviorWritingScreen(
                 }
             }
             .addFocusCleaner(focusManager)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(bottom = screenHeightDp(bottomPadding))
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_left),
             contentDescription = "back button",
             tint = ByeBooTheme.colors.white,
             modifier = modifier
-                .padding(
-                    top = screenHeightDp((27.dp) + bottomPadding),
-                    bottom = screenHeightDp(16.dp)
-                )
+                .padding(horizontal = screenWidthDp(24.dp))
                 .align(Alignment.Start)
                 .clickable(onClick = onBackClick)
         )
 
+        Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+
         LazyColumn(
-            modifier = modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(
+                start = screenWidthDp(24.dp),
+                end = screenWidthDp(24.dp),
+            )
         ) {
             item {
                 Row(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
@@ -1,5 +1,6 @@
 package com.byeboo.app.presentation.quest.behavior.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -27,7 +28,7 @@ fun NavGraphBuilder.questBehaviorGraph(
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     navigateUp: () -> Unit,
-    bottomPadding: Dp
+    paddingValues: PaddingValues
 ) {
     routeNavigation<QuestBehavior, QuestBehaviorWriting> {
         composable<QuestBehaviorWriting> {
@@ -37,7 +38,7 @@ fun NavGraphBuilder.questBehaviorGraph(
                 navigateToQuestBehaviorComplete = navigateToQuestBehaviorComplete,
                 navigateToQuestReview = navigateToQuestReview,
                 navigateUp = navigateUp,
-                bottomPadding = bottomPadding
+                paddingValues = paddingValues
             )
         }
 
@@ -45,7 +46,7 @@ fun NavGraphBuilder.questBehaviorGraph(
             QuestBehaviorCompleteRoute(
                 navigateToQuest = navigateToQuest,
                 navigateToOffboardingCompletedGuide = navigateToOffboardingCompletedGuide,
-                bottomPadding = bottomPadding
+                paddingValues = paddingValues
             )
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -1,6 +1,6 @@
 package com.byeboo.app.presentation.quest.navigation
 
-import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -53,7 +53,7 @@ fun NavGraphBuilder.questGraph(
     navigateToQuestBehaviorEdit: (Long, Boolean, String) -> Unit,
     navigateToQuestTip: (Long, QuestType) -> Unit,
     navigateToQuestBehaviorComplete: (Long) -> Unit,
-    padding: Dp
+    paddingValues: PaddingValues
 ) {
     routeNavigation<Quest, QuestStart> {
         composable<QuestStart> { backStackEntry ->
@@ -64,7 +64,7 @@ fun NavGraphBuilder.questGraph(
                 journey = journey,
                 navigateToQuest = navigateToQuest,
                 navigateToHome = navigateToHome,
-                padding = padding
+                paddingValues = paddingValues
             )
         }
 
@@ -77,7 +77,7 @@ fun NavGraphBuilder.questGraph(
                 navigateToQuestBehavior = navigateToQuestBehavior,
                 navigateToQuestReview = navigateToQuestReview,
                 navigateToOffboardingCompleteGuide = navigateToOffboardingCompleteGuide,
-                bottomPadding = padding
+                paddingValues = paddingValues
             )
         }
 
@@ -90,7 +90,7 @@ fun NavGraphBuilder.questGraph(
                 questId = questId,
                 navigateToQuest = navigateUp,
                 questType = questType,
-                bottomPadding = padding
+                paddingValues = paddingValues
             )
         }
 
@@ -99,7 +99,7 @@ fun NavGraphBuilder.questGraph(
                 navigateToQuest = navigateToQuest,
                 navigateToQuestRecordingEdit = navigateToQuestRecordingEdit,
                 navigateToQuestBehaviorEdit = navigateToQuestBehaviorEdit,
-                bottomPadding = padding
+                paddingValues = paddingValues
             )
         }
 
@@ -110,7 +110,7 @@ fun NavGraphBuilder.questGraph(
             navigateToQuestReview = navigateToQuestReview,
             navigateToOffboardingCompletedGuide = navigateToOffboardingCompleteGuide,
             navigateUp = navigateUp,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
 
         questBehaviorGraph(
@@ -120,7 +120,7 @@ fun NavGraphBuilder.questGraph(
             navigateToQuestReview = navigateToQuestReview,
             navigateToOffboardingCompletedGuide = navigateToOffboardingCompleteGuide,
             navigateUp = navigateUp,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,7 +26,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,7 +48,7 @@ import com.byeboo.app.presentation.quest.component.type.QuestContentType
 fun QuestRecordingCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: QuestRecordingCompleteViewModel = hiltViewModel()
 ) {
@@ -76,7 +76,7 @@ fun QuestRecordingCompleteRoute(
 
     QuestRecordingCompleteScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onCloseClick = viewModel::onCloseClicked,
         modifier = modifier
     )
@@ -85,7 +85,7 @@ fun QuestRecordingCompleteRoute(
 @Composable
 private fun QuestRecordingCompleteScreen(
     uiState: QuestRecordingCompleteState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -93,13 +93,15 @@ private fun QuestRecordingCompleteScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(bottom =  bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
-        Spacer(modifier = Modifier.height(screenHeightDp(67.dp)))
-
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = screenHeightDp(24.dp)),
             horizontalArrangement = Arrangement.End
         ) {
             Icon(
@@ -113,13 +115,16 @@ private fun QuestRecordingCompleteScreen(
         Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
 
         LazyColumn(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            contentPadding = PaddingValues(
+                start = screenWidthDp(24.dp),
+                top = screenHeightDp(8.dp),
+                end = screenWidthDp(24.dp),
+                bottom = screenHeightDp(24.dp)
+            )
         ) {
             item {
-                Spacer(modifier = Modifier.height(screenHeightDp(8.dp)))
-
                 QuestCompleteCard(
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -180,8 +185,6 @@ private fun QuestRecordingCompleteScreen(
                         questEmotionDescription = uiState.emotionDescription,
                         emotionType = uiState.selectedEmotion
                     )
-
-                    Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
                 }
             }
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
@@ -94,7 +94,7 @@ private fun QuestRecordingCompleteScreen(
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingCompleteScreen.kt
@@ -101,7 +101,7 @@ private fun QuestRecordingCompleteScreen(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = screenHeightDp(24.dp)),
+                .padding(horizontal = screenWidthDp(24.dp)),
             horizontalArrangement = Arrangement.End
         ) {
             Icon(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingScreen.kt
@@ -159,7 +159,7 @@ private fun QuestRecordingScreen(
             }
             .addFocusCleaner(focusManager)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/QuestRecordingScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,7 +35,6 @@ import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -65,7 +65,7 @@ fun QuestRecordingRoute(
     navigateToQuestRecordingComplete: (Long) -> Unit,
     navigateToQuestReview: (Long) -> Unit,
     navigateUp: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: QuestRecordingViewModel = hiltViewModel()
 ) {
@@ -107,7 +107,7 @@ fun QuestRecordingRoute(
 
     QuestRecordingScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onBackClick = viewModel::onBackClicked,
         onTipClick = viewModel::onTipClicked,
         onClickCompleteButton = viewModel::onClickCompleteButton,
@@ -123,7 +123,7 @@ fun QuestRecordingRoute(
 @Composable
 private fun QuestRecordingScreen(
     uiState: QuestRecordingState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onBackClick: () -> Unit,
     onTipClick: () -> Unit,
     onClickCompleteButton: () -> Unit,
@@ -158,24 +158,27 @@ private fun QuestRecordingScreen(
                 }
             }
             .addFocusCleaner(focusManager)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_left),
             contentDescription = "back button",
             tint = ByeBooTheme.colors.white,
             modifier = Modifier
-                .padding(
-                    top = screenHeightDp((67.dp)),
-                    bottom = screenHeightDp(16.dp)
-                )
+                .padding(start = screenWidthDp(24.dp))
                 .align(Alignment.Start)
                 .clickable { onBackClick() }
         )
 
+        Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+
         LazyColumn(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            contentPadding = PaddingValues(screenWidthDp(24.dp))
         ) {
             item {
                 Spacer(modifier = Modifier.height(screenHeightDp(10.dp)))
@@ -294,7 +297,8 @@ private fun QuestRecordingScreen(
             buttonText = "완료하기",
             buttonDisableTextColor = ByeBooTheme.colors.gray300,
             onClick = onClickCompleteButton,
-            isEnabled = QuestContentLengthValidator.validButton(uiState.questAnswer)
+            isEnabled = QuestContentLengthValidator.validButton(uiState.questAnswer),
+            modifier = Modifier.padding(horizontal = screenWidthDp(24.dp))
         )
 
         Spacer(modifier = Modifier.height(screenHeightDp(10.dp)))

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
@@ -1,5 +1,6 @@
 package com.byeboo.app.presentation.quest.record.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -27,7 +28,7 @@ fun NavGraphBuilder.questRecordGraph(
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     navigateUp: () -> Unit,
-    bottomPadding: Dp
+    paddingValues: PaddingValues
 ) {
     routeNavigation<QuestRecord, QuestRecording> {
         composable<QuestRecording> {
@@ -37,7 +38,7 @@ fun NavGraphBuilder.questRecordGraph(
                 navigateToQuestRecordingComplete = navigateToQuestRecordingComplete,
                 navigateToQuestReview = navigateToQuestReview,
                 navigateUp = navigateUp,
-                bottomPadding = bottomPadding
+                paddingValues = paddingValues
             )
         }
 
@@ -45,7 +46,7 @@ fun NavGraphBuilder.questRecordGraph(
             QuestRecordingCompleteRoute(
                 navigateToQuest = navigateToQuest,
                 navigateToOffboardingCompletedGuide = navigateToOffboardingCompletedGuide,
-                bottomPadding = bottomPadding
+                paddingValues = paddingValues
             )
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/QuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/QuestReviewScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -30,7 +31,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -52,7 +52,7 @@ import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun QuestReviewRoute(
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     navigateToQuest: () -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, String) -> Unit,
@@ -79,7 +79,7 @@ fun QuestReviewRoute(
 
     QuestReviewScreen(
         uiState = uiState,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onEditClick = { viewModel.onEditClicked(uiState.questType) },
         onCancelClick = viewModel::onCancelClicked,
         modifier = modifier
@@ -89,7 +89,7 @@ fun QuestReviewRoute(
 @Composable
 private fun QuestReviewScreen(
     uiState: QuestReviewState,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onEditClick: () -> Unit,
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -98,13 +98,15 @@ private fun QuestReviewScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
-        Spacer(modifier = Modifier.height(screenHeightDp(67.dp)))
-
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = screenWidthDp(24.dp)),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Icon(
@@ -125,11 +127,15 @@ private fun QuestReviewScreen(
         Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
 
         LazyColumn(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(
+                start = screenWidthDp(24.dp),
+                top = screenHeightDp(10.dp),
+                end = screenWidthDp(24.dp),
+                bottom = screenHeightDp(28.dp)
+            )
         ) {
             item {
-                Spacer(modifier = Modifier.height(screenHeightDp(10.dp)))
-
                 QuestTitle(
                     stepNumber = uiState.stepNumber,
                     questNumber = uiState.questNumber,
@@ -213,8 +219,6 @@ private fun QuestReviewScreen(
                     questEmotionDescription = uiState.emotionDescription,
                     emotionType = uiState.selectedEmotion
                 )
-
-                Spacer(modifier = Modifier.height(screenHeightDp(28.dp)))
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/QuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/QuestReviewScreen.kt
@@ -99,7 +99,7 @@ private fun QuestReviewScreen(
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
@@ -81,7 +81,7 @@ private fun QuestStartScreen(
                 top = paddingValues.calculateTopPadding(),
                 bottom = paddingValues.calculateBottomPadding()
             ),
-        contentPadding = PaddingValues(top = screenHeightDp(27.dp), bottom = screenHeightDp(10.dp))
+        contentPadding = PaddingValues(top = screenHeightDp(43.dp), bottom = screenHeightDp(10.dp))
     ) {
         item {
             Row(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/start/QuestStartScreen.kt
@@ -39,7 +39,7 @@ fun QuestStartRoute(
     journey: QuestType?,
     navigateToQuest: () -> Unit,
     navigateToHome: () -> Unit,
-    padding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: QuestStartViewModel = hiltViewModel()
 ) {
@@ -60,7 +60,7 @@ fun QuestStartRoute(
         uiState = uiState,
         onBackClick = viewModel::onBackClicked,
         onStartClick = { viewModel.onStartClicked(journey) },
-        padding = padding,
+        paddingValues = paddingValues,
         modifier = modifier
     )
 }
@@ -70,21 +70,23 @@ private fun QuestStartScreen(
     uiState: QuestStartState,
     onBackClick: () -> Unit,
     onStartClick: () -> Unit,
-    padding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
         modifier = modifier
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
-            .padding(bottom = padding),
-        contentPadding = PaddingValues(bottom = screenHeightDp(10.dp))
+            .padding(
+                top = paddingValues.calculateTopPadding(),
+                bottom = paddingValues.calculateBottomPadding()
+            ),
+        contentPadding = PaddingValues(top = screenHeightDp(27.dp), bottom = screenHeightDp(10.dp))
     ) {
         item {
             Row(
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(top = screenHeightDp(67.dp))
                     .padding(horizontal = screenWidthDp(24.dp)),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
@@ -118,8 +120,7 @@ private fun QuestStartScreen(
                 buttonStyle = ByeBooTheme.typography.body2,
                 buttonTextColor = ByeBooTheme.colors.white,
                 buttonBackgroundColor = ByeBooTheme.colors.primary300,
-                modifier = Modifier
-                    .padding(horizontal = screenWidthDp(24.dp))
+                modifier = Modifier.padding(horizontal = screenWidthDp(24.dp))
             )
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/tip/QuestTipScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/tip/QuestTipScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -45,7 +45,7 @@ fun QuestTipRoute(
     questId: Long,
     navigateToQuest: () -> Unit,
     questType: QuestType,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: QuestTipViewModel = hiltViewModel(),
     questViewModel: QuestViewModel = hiltViewModel()
@@ -76,7 +76,7 @@ fun QuestTipRoute(
         uiState = uiState,
         onCloseClick = viewModel::onCloseClicked,
         questType = questType,
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         modifier = modifier
     )
 }
@@ -86,21 +86,22 @@ private fun QuestTipScreen(
     uiState: QuestTipState,
     onCloseClick: () -> Unit,
     questType: QuestType,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
-            .padding(horizontal = screenWidthDp(24.dp))
-            .padding(bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
-        Spacer(modifier = Modifier.height(screenHeightDp(67.dp)))
-
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(horizontal = screenWidthDp(24.dp))
                 .padding(bottom = screenHeightDp(16.dp))
         ) {
             Icon(
@@ -123,12 +124,15 @@ private fun QuestTipScreen(
         }
 
         LazyColumn(
-            modifier = Modifier
-                .fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(
+                start = screenWidthDp(24.dp),
+                top = screenHeightDp(10.dp),
+                end = screenWidthDp(24.dp),
+                bottom = screenHeightDp(24.dp)
+            )
         ) {
             item {
-                Spacer(modifier = Modifier.height(screenHeightDp(10.dp)))
-
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center,
@@ -221,8 +225,6 @@ private fun QuestTipScreen(
                     titleText = "이 퀘스트가 끝나면 어떤 변화가 생길까요?",
                     contentText = uiState.tipAnswer.change
                 )
-
-                Spacer(modifier = Modifier.height(screenHeightDp(24.dp)))
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/tip/QuestTipScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/tip/QuestTipScreen.kt
@@ -94,7 +94,7 @@ private fun QuestTipScreen(
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -54,7 +55,7 @@ fun SplashRoute(
     navigateToHome: () -> Unit,
     navigateToUserInfo: () -> Unit,
     navigateToTermsOfService: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: SplashViewModel = hiltViewModel()
 ) {
@@ -107,7 +108,7 @@ fun SplashRoute(
     }
 
     SplashScreen(
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         showLoginButton = showLoginButton,
         onClick = {
             val availableButton = UserApiClient.instance.isKakaoTalkLoginAvailable(context)
@@ -119,7 +120,7 @@ fun SplashRoute(
 
 @Composable
 private fun SplashScreen(
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     showLoginButton: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -163,7 +164,7 @@ private fun SplashScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = screenWidthDp(24.dp))
-                .padding(bottom = screenHeightDp( 10.dp) + bottomPadding)
+                .padding(bottom = screenHeightDp( 10.dp) + paddingValues.calculateBottomPadding())
                 .offset(y = upAnimation)
         ) {
             Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/byeboo/app/presentation/splash/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/navigation/SplashNavigation.kt
@@ -1,5 +1,6 @@
 package com.byeboo.app.presentation.splash.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -23,21 +24,21 @@ fun NavGraphBuilder.splashGraph(
     navigateToHome: () -> Unit,
     navigateToUserInfo: () -> Unit,
     navigateToTermsOfService: () -> Unit,
-    padding: Dp
+    paddingValues: PaddingValues
 ) {
     composable<Splash> {
         SplashRoute(
             navigateToHome = navigateToHome,
             navigateToUserInfo = navigateToUserInfo,
             navigateToTermsOfService = navigateToTermsOfService,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
     composable<Terms> {
         ByeBooBackHandler()
         TermsOfServiceRoute(
             navigateToUserInfo = navigateToUserInfo,
-            padding = padding
+            paddingValues = paddingValues
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -16,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -32,7 +32,7 @@ import com.byeboo.app.presentation.splash.termsofservice.component.TermsCheckBut
 @Composable
 fun TermsOfServiceRoute(
     navigateToUserInfo: () -> Unit,
-    padding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: TermsOfServiceViewModel = hiltViewModel()
 ) {
@@ -50,7 +50,7 @@ fun TermsOfServiceRoute(
 
     TermsOfServiceScreen(
         uiState = uiState,
-        padding = padding,
+        paddingValues= paddingValues,
         onTermsAllClicked = viewModel::onAllTermsClick,
         onCheckClick = { term -> viewModel.onTermsClick(term) },
         onTermsLinkClick = { url -> viewModel.onTermsLinkClicked(url) },
@@ -62,7 +62,7 @@ fun TermsOfServiceRoute(
 @Composable
 private fun TermsOfServiceScreen(
     uiState: TermsOfServiceUiState,
-    padding: Dp,
+    paddingValues: PaddingValues,
     onTermsAllClicked: () -> Unit,
     onCheckClick: (TermType) -> Unit,
     onTermsLinkClick: (String?) -> Unit,
@@ -83,7 +83,7 @@ private fun TermsOfServiceScreen(
         Column(
             modifier = Modifier
                 .padding(horizontal = screenWidthDp(24.dp))
-                .padding(top = screenHeightDp(107.dp), bottom = screenHeightDp(padding))
+                .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(67.dp), bottom = screenHeightDp(paddingValues.calculateBottomPadding()))
                 .fillMaxSize()
         ) {
             TermsHeader()

--- a/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/termsofservice/TermsOfServiceScreen.kt
@@ -83,7 +83,7 @@ private fun TermsOfServiceScreen(
         Column(
             modifier = Modifier
                 .padding(horizontal = screenWidthDp(24.dp))
-                .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(67.dp), bottom = screenHeightDp(paddingValues.calculateBottomPadding()))
+                .padding(top = paddingValues.calculateTopPadding() + screenHeightDp(67.dp), bottom = paddingValues.calculateBottomPadding())
                 .fillMaxSize()
         ) {
             TermsHeader()

--- a/app/src/main/java/com/byeboo/app/presentation/tutorial/TutorialScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/tutorial/TutorialScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,7 +25,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.byeboo.app.R
@@ -35,7 +35,7 @@ import com.byeboo.app.core.util.screenWidthDp
 @Composable
 fun TutorialRoute(
     navigateToUp: () -> Unit,
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
     viewModel: TutorialViewModel = hiltViewModel()
 ) {
@@ -48,7 +48,7 @@ fun TutorialRoute(
     }
 
     TutorialScreen(
-        bottomPadding = bottomPadding,
+        paddingValues = paddingValues,
         onBackClick = viewModel::onBackClicked,
         modifier = modifier
     )
@@ -56,7 +56,7 @@ fun TutorialRoute(
 
 @Composable
 private fun TutorialScreen(
-    bottomPadding: Dp,
+    paddingValues: PaddingValues,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -65,7 +65,10 @@ private fun TutorialScreen(
             .fillMaxSize()
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
-            .padding(top = screenHeightDp(67.dp), bottom = bottomPadding)
+            .padding(
+                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                bottom = paddingValues.calculateBottomPadding()
+            )
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_cancel),
@@ -81,6 +84,7 @@ private fun TutorialScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = screenWidthDp((14.5).dp))
+                .padding(top = screenHeightDp(24.dp), bottom = screenHeightDp(16.dp))
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -107,8 +111,6 @@ private fun TutorialScreen(
                     Spacer(modifier = Modifier.height(screenHeightDp(32.dp)))
                 }
             }
-
-            Spacer(modifier = Modifier.height(screenHeightDp(12.dp)))
         }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/tutorial/TutorialScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/tutorial/TutorialScreen.kt
@@ -66,7 +66,7 @@ private fun TutorialScreen(
             .background(color = ByeBooTheme.colors.black)
             .padding(horizontal = screenWidthDp(24.dp))
             .padding(
-                top = paddingValues.calculateTopPadding() + screenHeightDp(27.dp),
+                top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                 bottom = paddingValues.calculateBottomPadding()
             )
     ) {

--- a/app/src/main/java/com/byeboo/app/presentation/tutorial/navigation/TutorialNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/tutorial/navigation/TutorialNavigation.kt
@@ -1,6 +1,6 @@
 package com.byeboo.app.presentation.tutorial.navigation
 
-import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -15,12 +15,12 @@ fun NavController.navigateToTutorial(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.tutorialGraph(
     navigateToUp: () -> Unit,
-    padding: Dp
+    paddingValues: PaddingValues
 ) {
     composable<Tutorial> {
         TutorialRoute(
             navigateToUp = navigateToUp,
-            bottomPadding = padding
+            paddingValues = paddingValues
         )
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #251

## Work Description 📝
- 기존에 고정값으로 시스템바 포함해서 주고 있던 상단 패딩을 수정하였습니다
- 몇몇 화면 패딩 적용되어 있는 부분이 스크롤 안 되고 있던 문제도 있어서 해결했습니다.

## Screenshot 📸


## Uncompleted Tasks 😅
- N/A

## PR Point 📌
상단, 하단 시스템 패딩 계산 처리를 화면에서 하도록 하였는데 괜찮으신지요~~??
단순히 값만 계산하는 거 + 상태에 따라 변하지도 않음 => UI만 나타내고 있으므로 화면에 위치시켜도 된다고 판단하긴 했습니다아~~


## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 앱 전반의 화면 패딩 전달 방식을 통일하고 레이아웃 패딩 계산을 개선했습니다. 여러 화면의 상/하 여백 처리와 스크롤 콘텐츠 여백이 일관되게 변경되어 인셋 처리와 레이아웃 안정성이 향상되고 일부 화면의 내부 간격이 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->