### PR TITLE
[fix/#247] 퀘스트 오픈 푸시 알림 QA 수정

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/fcm/FcmTokenRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/fcm/FcmTokenRepositoryImpl.kt
@@ -15,6 +15,12 @@ class FcmTokenRepositoryImpl @Inject constructor(
 ): FcmTokenRepository {
     override suspend fun saveFcmToken(fcmToken: FcmTokenModel): Result<Unit> {
         return runCatching {
+            val savedLocalToken = fcmLocalDataSource.getFcmToken()
+
+            if (savedLocalToken == fcmToken.token) {
+                return@runCatching
+            }
+
             fcmRemoteDataSource.saveFcmToken(fcmToken.toData())
             fcmLocalDataSource.saveFcmToken(fcmToken.token)
 

--- a/app/src/main/java/com/byeboo/app/fcm/ByebooMessagingService.kt
+++ b/app/src/main/java/com/byeboo/app/fcm/ByebooMessagingService.kt
@@ -40,10 +40,9 @@ class ByebooMessagingService : FirebaseMessagingService() {
 
         val title = message.notification?.title
         val body = message.notification?.body
-        val questId = message.data["questId"]
 
         message.notification?.let {
-            notificationHandler.showNotification(title, body, questId)
+            notificationHandler.showNotification(title, body)
         }
     }
 

--- a/app/src/main/java/com/byeboo/app/fcm/ByebooNotificationHandler.kt
+++ b/app/src/main/java/com/byeboo/app/fcm/ByebooNotificationHandler.kt
@@ -17,13 +17,12 @@ class ByebooNotificationHandler @Inject constructor(
 ) {
     fun showNotification(
         title: String?,
-        message: String?,
-        questId: String?
+        message: String?
     ) {
         val notifyId = System.currentTimeMillis().toInt()
 
         val intent = Intent(context, MainActivity::class.java).apply {
-            putExtra("questId", questId)
+            putExtra(DESTINATION, QUEST_HOME)
             addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         }
 
@@ -50,5 +49,7 @@ class ByebooNotificationHandler @Inject constructor(
     companion object {
         const val CHANNEL_ID = "BYEBOO"
         const val CHANNEL_NAME = "Byeboo 알림 채널"
+        const val DESTINATION = "destination"
+        const val QUEST_HOME = "questHome"
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
@@ -5,8 +5,10 @@ import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
+import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,6 +24,12 @@ class MainActivity : ComponentActivity() {
         )
 
         viewModel.handleIntent(intent)
+
+        setContent {
+            ByeBooTheme{
+                MainScreen()
+            }
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
@@ -5,12 +5,8 @@ import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
-import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
-import androidx.compose.runtime.getValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -26,17 +22,6 @@ class MainActivity : ComponentActivity() {
         )
 
         viewModel.handleIntent(intent)
-
-        setContent {
-            val notificationQuestId by viewModel.notificationQuestId.collectAsStateWithLifecycle()
-
-            ByeBooTheme {
-                MainScreen(
-                    notificationQuestId = notificationQuestId,
-                    onClearQuestId = { viewModel.clearNotificationQuestId() }
-                )
-            }
-        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainScreen.kt
@@ -36,9 +36,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
-    viewModel: MainViewModel = hiltViewModel(),
-    notificationQuestId: String? = null,
-    onClearQuestId: () -> Unit = {}
+    viewModel: MainViewModel = hiltViewModel()
 ) {
     val scope = rememberCoroutineScope()
     val snackBarHostState = remember { SnackbarHostState() }
@@ -46,6 +44,7 @@ fun MainScreen(
     val currentTab = navigator.currentTab
     val showBottomBar = navigator.showBottomBar()
     val status by viewModel.journeyStatus.collectAsStateWithLifecycle()
+    val isMoveToQuestHome by viewModel.questHomeNavigation.collectAsStateWithLifecycle()
 
     val onShowSnackBar: (String) -> Unit = { message ->
         scope.launch {
@@ -108,10 +107,12 @@ fun MainScreen(
         }
     }
 
-    LaunchedEffect(notificationQuestId, status) {
-        if (notificationQuestId != null && status!= null && !isNavigating) {
+    LaunchedEffect(isMoveToQuestHome, status) {
+        if (isMoveToQuestHome && !isNavigating && status != JourneyStatusType.UNKNOWN) {
+            delay(100L)
             moveToQuestNavigation()
-            onClearQuestId()
+            delay(50L)
+            viewModel.clearNavigateQuestHome()
         }
     }
 

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
@@ -20,8 +20,6 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val questStateRepository: QuestStateRepository,
-    private val fcmTokenRepository: FcmTokenRepository,
-    private val userRepository: UserRepository,
     private val mixpanelUtil: MixpanelUtil
 ) : ViewModel() {
     val journeyStatus: StateFlow<JourneyStatusType> = questStateRepository.getUserJourneyStatus()

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.domain.model.JourneyStatusType
-import com.byeboo.app.domain.repository.auth.UserRepository
-import com.byeboo.app.domain.repository.fcm.FcmTokenRepository
 import com.byeboo.app.domain.repository.quest.QuestStateRepository
+import com.byeboo.app.fcm.ByebooNotificationHandler.Companion.DESTINATION
+import com.byeboo.app.fcm.ByebooNotificationHandler.Companion.QUEST_HOME
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,8 +25,8 @@ class MainViewModel @Inject constructor(
     val journeyStatus: StateFlow<JourneyStatusType> = questStateRepository.getUserJourneyStatus()
         .stateIn(viewModelScope, SharingStarted.Eagerly, JourneyStatusType.UNKNOWN)
 
-    private val _notificationQuestId = MutableStateFlow<String?>(null)
-    val notificationQuestId: StateFlow<String?> = _notificationQuestId.asStateFlow()
+    private val _questHomeNavigation = MutableStateFlow<Boolean>(false)
+    val questHomeNavigation: StateFlow<Boolean> = _questHomeNavigation.asStateFlow()
 
     fun trackJourneyStart() {
         viewModelScope.launch {
@@ -42,17 +42,14 @@ class MainViewModel @Inject constructor(
     }
 
     fun handleIntent(intent: Intent) {
-        val questId = intent.getStringExtra("questId")
-        if (questId != null) {
-            updateNotificationQuestId(questId)
+        val destination = intent.getStringExtra(DESTINATION)
+
+        if (destination == QUEST_HOME) {
+            _questHomeNavigation.value = true
         }
     }
-    
-    fun updateNotificationQuestId(questId: String?) {
-        _notificationQuestId.value = questId
-    }
 
-    fun clearNotificationQuestId() {
-        _notificationQuestId.value = null
+    fun clearNavigateQuestHome() {
+        _questHomeNavigation.value = false
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -162,10 +162,6 @@ fun MyPageRoute(
         )
     }
 
-//    LaunchedEffect(Unit) {
-//        viewModel.loadAlarmStatus()
-//    }
-
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { effect ->
             when (effect) {

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageScreen.kt
@@ -52,6 +52,7 @@ import com.byeboo.app.core.util.hasNotificationPermission
 import com.byeboo.app.core.util.openUrl
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
+import com.byeboo.app.presentation.mypage.component.BasicNotificationModal
 import com.byeboo.app.presentation.mypage.component.MyPageModal
 import com.byeboo.app.presentation.mypage.component.MyPageNotification
 
@@ -76,32 +77,58 @@ fun MyPageRoute(
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = { isGranted ->
-            viewModel.onPermissionResult(isGranted)
+            if (isGranted) {
+                viewModel.onPermissionResult(true)
+            } else {
+                val showRationale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    activity?.shouldShowRequestPermissionRationale(POST_NOTIFICATIONS) == true
+                } else false
+
+                if (!showRationale) {
+                    viewModel.onAlarmToggledClicked(hasSystemPermission = false)
+                } else {
+                    viewModel.onPermissionResult(false)
+                }
+            }
         }
     )
 
     val onAlarmToggleClick = {
-        val hasPermission = context.hasNotificationPermission()
-        val isPermissionNeeded = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            activity?.shouldShowRequestPermissionRationale(POST_NOTIFICATIONS) == true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (context.hasNotificationPermission()) {
+                viewModel.onAlarmToggledClicked(true)
+            } else {
+                val shouldShowRationale =
+                    activity?.shouldShowRequestPermissionRationale(POST_NOTIFICATIONS) == true
+
+                if (shouldShowRationale) {
+                    viewModel.onAlarmToggledClicked(false)
+                } else {
+                    permissionLauncher.launch(POST_NOTIFICATIONS)
+                }
+            }
         } else {
-            false
+            viewModel.onAlarmToggledClicked(true)
         }
-        viewModel.onAlarmToggledClicked(hasPermission, isPermissionNeeded)
     }
 
     if (uiState.showPermissionModal) {
-        MyPageModal(
+        BasicNotificationModal(
             onDismissRequest = { viewModel.onDismissModal(ModalType.PERMISSION) },
-            myPageModalMainText = "알림 권한 필요",
-            myPageModalSubText = "알림을 받으려면 설정에서 권한을 허용해야 합니다.",
-            onCancelClick = { viewModel.onDismissModal(ModalType.PERMISSION) },
-            onConfirmClick = viewModel::onGoToSettingClicked,
-            onConfirmText = "허용하기",
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = screenWidthDp(48.dp)),
-            dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
+            onConfirmClick = {
+                viewModel.onDismissModal(ModalType.PERMISSION)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    val shouldShowRationale =
+                        activity?.shouldShowRequestPermissionRationale(POST_NOTIFICATIONS) == true
+
+                    if (shouldShowRationale) {
+                        permissionLauncher.launch(POST_NOTIFICATIONS)
+
+                    } else {
+                        viewModel.onGoToSettingClicked()
+                    }
+                }
+            }
         )
     }
 
@@ -134,6 +161,10 @@ fun MyPageRoute(
             dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
         )
     }
+
+//    LaunchedEffect(Unit) {
+//        viewModel.loadAlarmStatus()
+//    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { effect ->

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MyPageState.kt
@@ -2,7 +2,7 @@ package com.byeboo.app.presentation.mypage
 
 data class MyPageState(
     val nickname: String = "",
-    val isAlarmEnabled: Boolean = false,
+    val isAlarmEnabled: Boolean? = null,
     val showLogoutModal: Boolean = false,
     val showDeleteAccountModal: Boolean = false,
     val showPermissionModal: Boolean = false

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
@@ -65,15 +65,17 @@ class MyPageViewModel @Inject constructor(
     fun onAlarmToggledClicked(hasSystemPermission: Boolean) {
         val isAlarmEnabled = _uiState.value.isAlarmEnabled
 
-        if (isAlarmEnabled) {
-            updateAlarmStatus()
-        } else {
-            // [off -> on]
-            // 권한 있을 경우
-            if (hasSystemPermission) {
+        isAlarmEnabled?.let {
+            if (isAlarmEnabled) {
                 updateAlarmStatus()
             } else {
-                _uiState.update { it.copy(showPermissionModal = true) }
+                // [off -> on]
+                // 권한 있을 경우
+                if (hasSystemPermission) {
+                    updateAlarmStatus()
+                } else {
+                    _uiState.update { it.copy(showPermissionModal = true) }
+                }
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
@@ -38,14 +38,6 @@ class MyPageViewModel @Inject constructor(
             userRepository.getNickname().collect { nickname ->
                 _uiState.update { it.copy(nickname = nickname) }
             }
-            loadAlarmStatus()
-        }
-    }
-
-    fun loadAlarmStatus() {
-        viewModelScope.launch {
-            val isAlarmEnabled = fcmTokenRepository.isAlarmEnabled()
-            _uiState.update { it.copy(isAlarmEnabled = isAlarmEnabled) }
         }
     }
 
@@ -70,7 +62,7 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    fun onAlarmToggledClicked(hasSystemPermission: Boolean, isPermissionNeeded: Boolean) {
+    fun onAlarmToggledClicked(hasSystemPermission: Boolean) {
         val isAlarmEnabled = _uiState.value.isAlarmEnabled
 
         if (isAlarmEnabled) {
@@ -81,16 +73,7 @@ class MyPageViewModel @Inject constructor(
             if (hasSystemPermission) {
                 updateAlarmStatus()
             } else {
-                // 권한 없을 경우
-                if (isPermissionNeeded) {
-                    // 비허용 이력 있을 경우 -> 설정 모달
-                    _uiState.update { it.copy(showPermissionModal = true) }
-                } else {
-                    // 최초 시도 -> 시스템 팝업 요청
-                    viewModelScope.launch {
-                        _sideEffect.emit(MyPageSideEffect.RequestNotificationPermission)
-                    }
-                }
+                _uiState.update { it.copy(showPermissionModal = true) }
             }
         }
     }
@@ -99,9 +82,16 @@ class MyPageViewModel @Inject constructor(
     fun onPermissionResult(isGranted: Boolean) {
         if (isGranted) {
             // 허용 -> 서버 토글 요청
-            updateAlarmStatus()
+            viewModelScope.launch {
+                _uiState.update { it.copy(isAlarmEnabled = true) }
+                fcmTokenRepository.saveAlarmEnabled(true)
+                updateAlarmStatus()
+            }
         } else {
             // 비허용 -> off 유지
+            _uiState.update {
+                it.copy(showPermissionModal = false, isAlarmEnabled = false)
+            }
         }
     }
 
@@ -116,6 +106,8 @@ class MyPageViewModel @Inject constructor(
                     fcmTokenRepository.saveAlarmEnabled(notificationSetting.alarmEnabled)
                 }
                 .onFailure {
+                    _uiState.update { it.copy(isAlarmEnabled = false) }
+                    fcmTokenRepository.saveAlarmEnabled(false)
                     MyPageSideEffect.ShowSnackBar("다시 시도해 주세요.")
                 }
         }
@@ -132,10 +124,14 @@ class MyPageViewModel @Inject constructor(
     // 설정 -> 앱 복귀 시 알람 상태 동기화
     fun syncAlarmState(hasSystemPermission: Boolean) {
         viewModelScope.launch {
-            if (!hasSystemPermission && _uiState.value.isAlarmEnabled) {
-                updateAlarmStatus()
+
+            if (!hasSystemPermission) {
+                _uiState.update { it.copy(isAlarmEnabled = false) }
+                fcmTokenRepository.saveAlarmEnabled(false)
+
             } else {
-                loadAlarmStatus()
+                val savedState = fcmTokenRepository.isAlarmEnabled()
+                _uiState.update { it.copy(isAlarmEnabled = savedState) }
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/MypageViewModel.kt
@@ -110,7 +110,6 @@ class MyPageViewModel @Inject constructor(
                 .onFailure {
                     _uiState.update { it.copy(isAlarmEnabled = false) }
                     fcmTokenRepository.saveAlarmEnabled(false)
-                    MyPageSideEffect.ShowSnackBar("다시 시도해 주세요.")
                 }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/component/BasicNotificationModal.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/component/BasicNotificationModal.kt
@@ -1,0 +1,36 @@
+package com.byeboo.app.presentation.mypage.component
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun BasicNotificationModal(
+    onDismissRequest: () -> Unit,
+    onConfirmClick: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    val currentOnDismissRequest = rememberUpdatedState(onDismissRequest)
+    val currentOnConfirmClick = rememberUpdatedState(onConfirmClick)
+
+    DisposableEffect(context) {
+        val dialog = MaterialAlertDialogBuilder(context)
+            .setMessage("알림 권한을 허용하시겠습니까?")
+            .setPositiveButton("허용하기") { _, _ ->
+                currentOnConfirmClick.value()
+            }
+            .setOnDismissListener {
+                currentOnDismissRequest.value()
+            }
+            .create()
+
+        dialog.show()
+
+        onDispose {
+            dialog.dismiss()
+        }
+    }
+}

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/component/MypageNotification.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/component/MypageNotification.kt
@@ -17,10 +17,12 @@ import com.byeboo.app.core.util.noRippleClickable
 @Composable
 fun MyPageNotification(
     modifier: Modifier = Modifier,
-    isEnabledAlarm: Boolean,
+    isEnabledAlarm: Boolean?,
     onCheckedClick: (Boolean) -> Unit
 ) {
-    val toggle = if (isEnabledAlarm) R.drawable.ic_toggle_on else R.drawable.ic_toggle_off
+    val toggle = if (isEnabledAlarm == true) R.drawable.ic_toggle_on else R.drawable.ic_toggle_off
+    val alpha = if (isEnabledAlarm == null) 0f else 1f
+
     Row(
         modifier = modifier
             .fillMaxWidth(),
@@ -37,9 +39,12 @@ fun MyPageNotification(
         Image(
             imageVector = ImageVector.vectorResource(toggle),
             contentDescription = "alarm toggle",
+            alpha = alpha,
             modifier = Modifier
                 .noRippleClickable(
-                    onClick = { onCheckedClick(!isEnabledAlarm) }
+                    onClick = {
+                        isEnabledAlarm?.let { onCheckedClick(!isEnabledAlarm) }
+                    }
                 )
         )
     }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
@@ -10,6 +10,7 @@ import com.byeboo.app.domain.repository.auth.UserRepository
 import com.byeboo.app.domain.repository.fcm.FcmTokenRepository
 import com.byeboo.app.domain.usecase.LoginUseCase
 import com.byeboo.app.domain.usecase.ReissueAccessTokenUseCase
+import com.byeboo.app.domain.usecase.UpdateFcmTokenUseCase
 import com.google.firebase.messaging.FirebaseMessaging
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.AuthError
@@ -31,7 +32,8 @@ class SplashViewModel @Inject constructor(
     private val fcmTokenRepository: FcmTokenRepository,
     private val mixpanelUtil: MixpanelUtil,
     private val loginUseCase: LoginUseCase,
-    private val reissueAccessTokenUseCase: ReissueAccessTokenUseCase
+    private val reissueAccessTokenUseCase: ReissueAccessTokenUseCase,
+    private val updateFcmTokenUseCase: UpdateFcmTokenUseCase
 ) : ViewModel() {
 
     private val _sideEffect = MutableSharedFlow<SplashStateSideEffect>()
@@ -63,7 +65,7 @@ class SplashViewModel @Inject constructor(
 
             val isRegistered = userRepository.isUserRegistered()
             if (isRegistered) {
-                saveFcmToken()
+                updateFcmToken()
                 userRepository.setLoggedIn(true)
                 _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
             } else {
@@ -81,7 +83,8 @@ class SplashViewModel @Inject constructor(
 
                 val isRegistered = userRepository.isUserRegistered()
                 if (isRegistered) {
-                    saveFcmToken()
+                    updateFcmToken()
+
                     userRepository.setLoggedIn(true)
                     _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
                 } else {
@@ -112,6 +115,8 @@ class SplashViewModel @Inject constructor(
                             mixpanelUtil.setDistinctId(auth.userId.toString())
                             mixpanelUtil.trackLogin(LoginType.KAKAO, true)
                             userRepository.setLoggedIn(true)
+
+                            saveFcmToken()
 
                             isRegisteredUser = auth.isRegistered
                             _sideEffect.emit(SplashStateSideEffect.RequestNotificationPermission)
@@ -159,6 +164,21 @@ class SplashViewModel @Inject constructor(
                         .onSuccess { Timber.d("Fcm 토큰 성공: $token") }
                         .onFailure { Timber.e(it, "Fcm 토큰 실패") }
 
+                }
+            }
+        }
+    }
+
+    private fun updateFcmToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                return@addOnCompleteListener
+            }
+
+            val token = task.result
+            viewModelScope.launch {
+                withContext(NonCancellable) {
+                    updateFcmTokenUseCase(token)
                 }
             }
         }

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
@@ -190,6 +190,8 @@ class SplashViewModel @Inject constructor(
                 if (isGranted) {
                     fcmTokenRepository.saveAlarmEnabled(true)
                     fcmTokenRepository.allowQuestAlarm()
+                } else {
+                    fcmTokenRepository.saveAlarmEnabled(false)
                 }
                 _sideEffect.emit(SplashStateSideEffect.NavigateToHome)
 


### PR DESCRIPTION
## Related issue 🛠
- closed #247 

## Work Description 📝
- 토큰 중복 저장 오류 수정
- 다이얼로그 수정
- 토글 상태 동기화 딜레이 수정
- 포그라운드, 백그라운드에서 알림 클릭 시, 퀘스트 홈으로 이동하도록 네비 수정

## Screenshot 📸

## Uncompleted Tasks 😅

## PR Point 📌

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  - 알림 권한 요청을 위한 간단한 권한 대화상자 추가

* **개선 사항**
  - 푸시 알림으로 앱 내 퀘스트 홈으로 바로 이동하는 네비게이션 흐름 개선
  - 안드로이드 버전별 권한 요청 및 설정 이동 흐름 정교화
  - 알람(알림) 설정 표시·토글 동작 안정화(초기값 허용/비활성화 상태 처리·동기화 개선)
  - FCM 토큰 갱신 흐름 강화 및 동일 토큰에 대한 중복 저장 방지

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->