### PR TITLE
[feat/#286] 차단 사용자 목록 화면 api 연결

### DIFF
--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/mypage/BlockedUsersDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/mypage/BlockedUsersDataSource.kt
@@ -1,0 +1,8 @@
+package com.byeboo.app.data.datasource.remote.mypage
+
+import com.byeboo.app.data.dto.base.NullableBaseResponse
+import com.byeboo.app.data.dto.response.mypage.BlockedUsersResponseDto
+
+interface BlockedUsersDataSource {
+    suspend fun getBlockedUsers(): NullableBaseResponse<BlockedUsersResponseDto>
+}

--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/mypage/BlockedUsersDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/mypage/BlockedUsersDataSource.kt
@@ -5,4 +5,6 @@ import com.byeboo.app.data.dto.response.mypage.BlockedUsersResponseDto
 
 interface BlockedUsersDataSource {
     suspend fun getBlockedUsers(): NullableBaseResponse<BlockedUsersResponseDto>
+
+    suspend fun unblockUser(blockId: Long): NullableBaseResponse<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/mypage/BlockedUsersDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/mypage/BlockedUsersDataSourceImpl.kt
@@ -12,4 +12,6 @@ class BlockedUsersDataSourceImpl
         private val blockedUsersService: BlockedUsersService,
     ) : BlockedUsersDataSource {
         override suspend fun getBlockedUsers(): NullableBaseResponse<BlockedUsersResponseDto> = blockedUsersService.getBlockedUsers()
+
+        override suspend fun unblockUser(blockId: Long): NullableBaseResponse<Unit> = blockedUsersService.unblockUser(blockId)
     }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/mypage/BlockedUsersDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/mypage/BlockedUsersDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.byeboo.app.data.datasourceimpl.remote.mypage
+
+import com.byeboo.app.data.datasource.remote.mypage.BlockedUsersDataSource
+import com.byeboo.app.data.dto.base.NullableBaseResponse
+import com.byeboo.app.data.dto.response.mypage.BlockedUsersResponseDto
+import com.byeboo.app.data.service.mypage.BlockedUsersService
+import javax.inject.Inject
+
+class BlockedUsersDataSourceImpl
+    @Inject
+    constructor(
+        private val blockedUsersService: BlockedUsersService,
+    ) : BlockedUsersDataSource {
+        override suspend fun getBlockedUsers(): NullableBaseResponse<BlockedUsersResponseDto> = blockedUsersService.getBlockedUsers()
+    }

--- a/app/src/main/java/com/byeboo/app/data/di/DataSourceModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/DataSourceModule.kt
@@ -4,6 +4,7 @@ import com.byeboo.app.data.datasource.remote.NewJourneyDataSource
 import com.byeboo.app.data.datasource.remote.auth.AuthRemoteDataSource
 import com.byeboo.app.data.datasource.remote.auth.UserRemoteDataSource
 import com.byeboo.app.data.datasource.remote.fcm.FcmRemoteDataSource
+import com.byeboo.app.data.datasource.remote.mypage.BlockedUsersDataSource
 import com.byeboo.app.data.datasource.remote.offboarding.OffboardingJourneyDataSource
 import com.byeboo.app.data.datasource.remote.offboarding.OffboardingQuestCompletedDataSource
 import com.byeboo.app.data.datasource.remote.quest.QuestBehaviorDataSource
@@ -17,6 +18,7 @@ import com.byeboo.app.data.datasourceimpl.remote.NewJourneyDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.auth.AuthRemoteDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.auth.UserRemoteDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.fcm.FcmRemoteDataSourceImpl
+import com.byeboo.app.data.datasourceimpl.remote.mypage.BlockedUsersDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.offboarding.OffboardingJourneyDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.offboarding.OffboardingQuestCompletedDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.quest.QuestBehaviorDataSourceImpl
@@ -88,4 +90,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindsFcmRemoteDataSource(impl: FcmRemoteDataSourceImpl): FcmRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsBlockedUsersDataSource(impl: BlockedUsersDataSourceImpl): BlockedUsersDataSource
 }

--- a/app/src/main/java/com/byeboo/app/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/RepositoryModule.kt
@@ -5,6 +5,7 @@ import com.byeboo.app.data.repositoryimpl.auth.AuthRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.auth.TokenRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.auth.UserRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.fcm.FcmTokenRepositoryImpl
+import com.byeboo.app.data.repositoryimpl.mypage.BlockedUsersRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.offboarding.OffboardingJourneyRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.OffboardingQuestCompletedRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestInProgressRepositoryImpl
@@ -20,6 +21,7 @@ import com.byeboo.app.domain.repository.auth.AuthRepository
 import com.byeboo.app.domain.repository.auth.TokenRepository
 import com.byeboo.app.domain.repository.auth.UserRepository
 import com.byeboo.app.domain.repository.fcm.FcmTokenRepository
+import com.byeboo.app.domain.repository.mypage.BlockedUsersRepository
 import com.byeboo.app.domain.repository.offboarding.OffboardingJourneyRepository
 import com.byeboo.app.domain.repository.offboarding.OffboardingQuestCompletedRepository
 import com.byeboo.app.domain.repository.quest.QuestBehaviorRepository
@@ -108,4 +110,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindFcmTokenRepository(fcmTokenRepositoryImpl: FcmTokenRepositoryImpl): FcmTokenRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindBlockedUsersRepository(blockedUsersRepositoryImpl: BlockedUsersRepositoryImpl): BlockedUsersRepository
 }

--- a/app/src/main/java/com/byeboo/app/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/ServiceModule.kt
@@ -4,6 +4,7 @@ import com.byeboo.app.core.network.qualifier.Auth
 import com.byeboo.app.data.service.NewJourneyService
 import com.byeboo.app.data.service.auth.AuthService
 import com.byeboo.app.data.service.auth.UserService
+import com.byeboo.app.data.service.mypage.BlockedUsersService
 import com.byeboo.app.data.service.notification.NotificationService
 import com.byeboo.app.data.service.offboarding.OffboardingJourneyService
 import com.byeboo.app.data.service.offboarding.OffboardingQuestCompletedService
@@ -107,5 +108,12 @@ object ServiceModule {
     fun providesNotificationService(retrofit: Retrofit): NotificationService =
         retrofit.create(
             NotificationService::class.java,
+        )
+
+    @Provides
+    @Singleton
+    fun providesBlockedUsersService(retrofit: Retrofit): BlockedUsersService =
+        retrofit.create(
+            BlockedUsersService::class.java,
         )
 }

--- a/app/src/main/java/com/byeboo/app/data/dto/response/mypage/BlockedUsersResponseDto.kt
+++ b/app/src/main/java/com/byeboo/app/data/dto/response/mypage/BlockedUsersResponseDto.kt
@@ -1,0 +1,18 @@
+package com.byeboo.app.data.dto.response.mypage
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BlockedUsersResponseDto(
+    @SerialName("blockList")
+    val blockList: List<BlockedUserDto>,
+)
+
+@Serializable
+data class BlockedUserDto(
+    @SerialName("name")
+    val name: String,
+    @SerialName("blockId")
+    val blockId: Long,
+)

--- a/app/src/main/java/com/byeboo/app/data/mapper/mypage/BlockedUsersMapper.kt
+++ b/app/src/main/java/com/byeboo/app/data/mapper/mypage/BlockedUsersMapper.kt
@@ -1,0 +1,17 @@
+package com.byeboo.app.data.mapper.mypage
+
+import com.byeboo.app.data.dto.response.mypage.BlockedUserDto
+import com.byeboo.app.data.dto.response.mypage.BlockedUsersResponseDto
+import com.byeboo.app.domain.model.mypage.BlockedUserModel
+import com.byeboo.app.domain.model.mypage.BlockedUsersModel
+
+fun BlockedUsersResponseDto.toDomain(): BlockedUsersModel =
+    BlockedUsersModel(
+        blockedUsers = blockList.map { it.toDomain() },
+    )
+
+fun BlockedUserDto.toDomain(): BlockedUserModel =
+    BlockedUserModel(
+        blockedUserName = this.name,
+        blockedUserId = this.blockId,
+    )

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/mypage/BlockedUsersRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/mypage/BlockedUsersRepositoryImpl.kt
@@ -13,6 +13,18 @@ class BlockedUsersRepositoryImpl
     ) : BlockedUsersRepository {
         override suspend fun getBlockedUsers(): Result<BlockedUsersModel> =
             runCatching {
-                blockedUsersDataSource.getBlockedUsers().data?.toDomain() ?: throw IllegalStateException()
+                blockedUsersDataSource.getBlockedUsers().data?.toDomain()
+                    ?: throw IllegalStateException()
+            }
+
+        override suspend fun unblockUser(blockId: Long): Result<Unit> =
+            runCatching {
+                val response = blockedUsersDataSource.unblockUser(blockId)
+
+                if (!response.success) {
+                    throw IllegalStateException(response.message)
+                }
+
+                Unit
             }
     }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/mypage/BlockedUsersRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/mypage/BlockedUsersRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.byeboo.app.data.repositoryimpl.mypage
+
+import com.byeboo.app.data.datasource.remote.mypage.BlockedUsersDataSource
+import com.byeboo.app.data.mapper.mypage.toDomain
+import com.byeboo.app.domain.model.mypage.BlockedUsersModel
+import com.byeboo.app.domain.repository.mypage.BlockedUsersRepository
+import javax.inject.Inject
+
+class BlockedUsersRepositoryImpl
+    @Inject
+    constructor(
+        private val blockedUsersDataSource: BlockedUsersDataSource,
+    ) : BlockedUsersRepository {
+        override suspend fun getBlockedUsers(): Result<BlockedUsersModel> =
+            runCatching {
+                blockedUsersDataSource.getBlockedUsers().data?.toDomain() ?: throw IllegalStateException()
+            }
+    }

--- a/app/src/main/java/com/byeboo/app/data/service/mypage/BlockedUsersService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/mypage/BlockedUsersService.kt
@@ -2,9 +2,16 @@ package com.byeboo.app.data.service.mypage
 
 import com.byeboo.app.data.dto.base.NullableBaseResponse
 import com.byeboo.app.data.dto.response.mypage.BlockedUsersResponseDto
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface BlockedUsersService {
     @GET("/api/v1/blocks")
     suspend fun getBlockedUsers(): NullableBaseResponse<BlockedUsersResponseDto>
+
+    @DELETE("/api/v1/blocks/{blockId}")
+    suspend fun unblockUser(
+        @Path("blockId") blockId: Long,
+    ): NullableBaseResponse<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/data/service/mypage/BlockedUsersService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/mypage/BlockedUsersService.kt
@@ -1,0 +1,10 @@
+package com.byeboo.app.data.service.mypage
+
+import com.byeboo.app.data.dto.base.NullableBaseResponse
+import com.byeboo.app.data.dto.response.mypage.BlockedUsersResponseDto
+import retrofit2.http.GET
+
+interface BlockedUsersService {
+    @GET("/api/v1/blocks")
+    suspend fun getBlockedUsers(): NullableBaseResponse<BlockedUsersResponseDto>
+}

--- a/app/src/main/java/com/byeboo/app/domain/model/mypage/BlockedUsersModel.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/mypage/BlockedUsersModel.kt
@@ -1,0 +1,10 @@
+package com.byeboo.app.domain.model.mypage
+
+data class BlockedUsersModel(
+    val blockedUsers: List<BlockedUserModel>,
+)
+
+data class BlockedUserModel(
+    val blockedUserName: String,
+    val blockedUserId: Long,
+)

--- a/app/src/main/java/com/byeboo/app/domain/repository/mypage/BlockedUsersRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/mypage/BlockedUsersRepository.kt
@@ -4,4 +4,6 @@ import com.byeboo.app.domain.model.mypage.BlockedUsersModel
 
 interface BlockedUsersRepository {
     suspend fun getBlockedUsers(): Result<BlockedUsersModel>
+
+    suspend fun unblockUser(blockId: Long): Result<Unit>
 }

--- a/app/src/main/java/com/byeboo/app/domain/repository/mypage/BlockedUsersRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/mypage/BlockedUsersRepository.kt
@@ -1,0 +1,7 @@
+package com.byeboo.app.domain.repository.mypage
+
+import com.byeboo.app.domain.model.mypage.BlockedUsersModel
+
+interface BlockedUsersRepository {
+    suspend fun getBlockedUsers(): Result<BlockedUsersModel>
+}

--- a/app/src/main/java/com/byeboo/app/domain/usecase/mypage/BlockedUsersUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/mypage/BlockedUsersUseCase.kt
@@ -1,0 +1,13 @@
+package com.byeboo.app.domain.usecase.mypage
+
+import com.byeboo.app.domain.model.mypage.BlockedUsersModel
+import com.byeboo.app.domain.repository.mypage.BlockedUsersRepository
+import javax.inject.Inject
+
+class BlockedUsersUseCase
+    @Inject
+    constructor(
+        private val blockedUsersRepository: BlockedUsersRepository,
+    ) {
+        suspend operator fun invoke(): Result<BlockedUsersModel> = blockedUsersRepository.getBlockedUsers()
+    }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/mypage/GetBlockedUsersUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/mypage/GetBlockedUsersUseCase.kt
@@ -4,7 +4,7 @@ import com.byeboo.app.domain.model.mypage.BlockedUsersModel
 import com.byeboo.app.domain.repository.mypage.BlockedUsersRepository
 import javax.inject.Inject
 
-class BlockedUsersUseCase
+class GetBlockedUsersUseCase
     @Inject
     constructor(
         private val blockedUsersRepository: BlockedUsersRepository,

--- a/app/src/main/java/com/byeboo/app/domain/usecase/mypage/UnblockUserUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/mypage/UnblockUserUseCase.kt
@@ -1,0 +1,13 @@
+package com.byeboo.app.domain.usecase.mypage
+
+import com.byeboo.app.domain.repository.mypage.BlockedUsersRepository
+import javax.inject.Inject
+import kotlin.Result
+
+class UnblockUserUseCase
+    @Inject
+    constructor(
+        private val blockedUsersRepository: BlockedUsersRepository,
+    ) {
+        suspend operator fun invoke(blockId: Long): Result<Unit> = blockedUsersRepository.unblockUser(blockId)
+    }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersScreen.kt
@@ -38,8 +38,8 @@ import com.byeboo.app.core.state.UiState
 import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
+import com.byeboo.app.domain.model.mypage.BlockedUserModel
 import com.byeboo.app.presentation.mypage.component.modal.BlockedUserModal
-import com.byeboo.app.presentation.mypage.type.User
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -115,7 +115,7 @@ private fun BlockedUsersScreen(
         )
 
         BlockedUsersSection(
-            userLists = state.userLists,
+            userLists = state.blockedUserLists,
             onUnblockClick = onUnblockClick,
         )
     }
@@ -154,7 +154,7 @@ private fun BlockedUsersHeader(
 
 @Composable
 private fun ColumnScope.BlockedUsersSection(
-    userLists: ImmutableList<User>,
+    userLists: ImmutableList<BlockedUserModel>,
     onUnblockClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -180,11 +180,11 @@ private fun ColumnScope.BlockedUsersSection(
     ) {
         items(
             items = userLists,
-            key = { it.id },
+            key = { it.blockedUserId },
         ) { user ->
             BlockedUser(
-                blockedUsername = user.name,
-                onUnblockClick = { onUnblockClick(user.id) },
+                blockedUsername = user.blockedUserName,
+                onUnblockClick = { onUnblockClick(user.blockedUserId) },
             )
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersScreen.kt
@@ -70,7 +70,7 @@ fun BlockedUsersRoute(
                 BlockedUserModal(
                     onDismissRequest = viewModel::onDismissModal,
                     onNoClick = viewModel::onDismissModal,
-                    onYesClick = viewModel::fetchBlockedUser,
+                    onYesClick = viewModel::unblockUser,
                     modifier =
                         Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersState.kt
@@ -2,13 +2,13 @@ package com.byeboo.app.presentation.mypage.blockedusers
 
 import androidx.compose.runtime.Immutable
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
-import com.byeboo.app.presentation.mypage.type.User
+import com.byeboo.app.domain.model.mypage.BlockedUserModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class BlockedUsersState(
-    val userLists: ImmutableList<User> = persistentListOf(),
+    val blockedUserLists: ImmutableList<BlockedUserModel> = persistentListOf(),
     val showBlockedModal: Boolean = false,
 )
 

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersState.kt
@@ -8,6 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class BlockedUsersState(
+    val selectedUserId: Long? = null,
     val blockedUserLists: ImmutableList<BlockedUserModel> = persistentListOf(),
     val showBlockedModal: Boolean = false,
 )

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersViewModel.kt
@@ -2,10 +2,13 @@ package com.byeboo.app.presentation.mypage.blockedusers
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.state.UiState
 import com.byeboo.app.core.util.updateSuccess
+import com.byeboo.app.domain.usecase.mypage.BlockedUsersUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +20,9 @@ import javax.inject.Inject
 @HiltViewModel
 class BlockedUsersViewModel
     @Inject
-    constructor() : ViewModel() {
+    constructor(
+        private val blockedUsersUseCase: BlockedUsersUseCase,
+    ) : ViewModel() {
         private val _uiState = MutableStateFlow<UiState<BlockedUsersState>>(UiState.Loading)
         val uiState: StateFlow<UiState<BlockedUsersState>> = _uiState.asStateFlow()
 
@@ -30,13 +35,30 @@ class BlockedUsersViewModel
 
         private fun loadBlockedUsers() {
             viewModelScope.launch {
-                _uiState.value =
-                    UiState.Success(
-                        BlockedUsersState(
-                            userLists = persistentListOf(), // 빈 리스트
-                            showBlockedModal = false,
-                        ),
-                    )
+                blockedUsersUseCase()
+                    .onSuccess { result ->
+                        _uiState.value =
+                            UiState.Success(
+                                BlockedUsersState(
+                                    blockedUserLists = result.blockedUsers.toImmutableList(),
+                                    showBlockedModal = false,
+                                ),
+                            )
+                    }.onFailure {
+                        _uiState.value =
+                            UiState.Success(
+                                BlockedUsersState(
+                                    blockedUserLists = persistentListOf(),
+                                    showBlockedModal = false,
+                                ),
+                            )
+
+                        _sideEffect.emit(
+                            BlockedUsersSideEffect.ShowSnackBar(
+                                snackBarType = CustomSnackBarType.ALERT,
+                            ),
+                        )
+                    }
             }
         }
 

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersViewModel.kt
@@ -1,6 +1,5 @@
 package com.byeboo.app.presentation.mypage.blockedusers
 
-import android.util.Log.e
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
@@ -17,7 +16,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -95,22 +93,19 @@ class BlockedUsersViewModel
             val currentState = _uiState.value as? UiState.Success ?: return
             val userId = currentState.data.selectedUserId ?: return
 
-            Timber.d("UNBLOCK userId=$userId")
-
             viewModelScope.launch {
                 onDismissModal()
                 unblockUserUseCase(blockId = userId)
                     .onSuccess {
-                        val before = ((_uiState.value as? UiState.Success)?.data?.blockedUserLists?.size)
-                        Timber.d("UNBLOCK before size=$before userId=$userId")
-
-                        _uiState.updateSuccess { state ->
-                            val newList = state.blockedUserLists.filterNot { it.blockedUserId == userId }.toImmutableList()
-                            Timber.d("UNBLOCK after size=${newList.size}")
-                            state.copy(blockedUserLists = newList)
+                        _uiState.updateSuccess {
+                            it.copy(
+                                blockedUserLists =
+                                    it.blockedUserLists
+                                        .filterNot { user -> user.blockedUserId == userId }
+                                        .toImmutableList(),
+                            )
                         }
-                    }.onFailure { e ->
-                        Timber.e(e, "unblock failed")
+                    }.onFailure {
                         _sideEffect.emit(
                             BlockedUsersSideEffect.ShowSnackBar(
                                 snackBarType = CustomSnackBarType.ALERT,

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/blockedusers/BlockedUsersViewModel.kt
@@ -1,11 +1,13 @@
 package com.byeboo.app.presentation.mypage.blockedusers
 
+import android.util.Log.e
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.state.UiState
 import com.byeboo.app.core.util.updateSuccess
-import com.byeboo.app.domain.usecase.mypage.BlockedUsersUseCase
+import com.byeboo.app.domain.usecase.mypage.GetBlockedUsersUseCase
+import com.byeboo.app.domain.usecase.mypage.UnblockUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -15,13 +17,15 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class BlockedUsersViewModel
     @Inject
     constructor(
-        private val blockedUsersUseCase: BlockedUsersUseCase,
+        private val getBlockedUsersUseCase: GetBlockedUsersUseCase,
+        private val unblockUserUseCase: UnblockUserUseCase,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<UiState<BlockedUsersState>>(UiState.Loading)
         val uiState: StateFlow<UiState<BlockedUsersState>> = _uiState.asStateFlow()
@@ -35,7 +39,7 @@ class BlockedUsersViewModel
 
         private fun loadBlockedUsers() {
             viewModelScope.launch {
-                blockedUsersUseCase()
+                getBlockedUsersUseCase()
                     .onSuccess { result ->
                         _uiState.value =
                             UiState.Success(
@@ -62,10 +66,10 @@ class BlockedUsersViewModel
             }
         }
 
-        // TODO: 서버 연결할 때, userId 관련 코드 수정 예정
         fun onUnblockClicked(userId: Long) {
             _uiState.updateSuccess {
                 it.copy(
+                    selectedUserId = userId,
                     showBlockedModal = true,
                 )
             }
@@ -87,6 +91,32 @@ class BlockedUsersViewModel
             }
         }
 
-        fun fetchBlockedUser() {
+        fun unblockUser() {
+            val currentState = _uiState.value as? UiState.Success ?: return
+            val userId = currentState.data.selectedUserId ?: return
+
+            Timber.d("UNBLOCK userId=$userId")
+
+            viewModelScope.launch {
+                onDismissModal()
+                unblockUserUseCase(blockId = userId)
+                    .onSuccess {
+                        val before = ((_uiState.value as? UiState.Success)?.data?.blockedUserLists?.size)
+                        Timber.d("UNBLOCK before size=$before userId=$userId")
+
+                        _uiState.updateSuccess { state ->
+                            val newList = state.blockedUserLists.filterNot { it.blockedUserId == userId }.toImmutableList()
+                            Timber.d("UNBLOCK after size=${newList.size}")
+                            state.copy(blockedUserLists = newList)
+                        }
+                    }.onFailure { e ->
+                        Timber.e(e, "unblock failed")
+                        _sideEffect.emit(
+                            BlockedUsersSideEffect.ShowSnackBar(
+                                snackBarType = CustomSnackBarType.ALERT,
+                            ),
+                        )
+                    }
+            }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/mypage/type/User.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/mypage/type/User.kt
@@ -1,9 +1,0 @@
-package com.byeboo.app.presentation.mypage.type
-
-import androidx.compose.runtime.Immutable
-
-@Immutable
-data class User(
-    val id: Long,
-    val name: String,
-)


### PR DESCRIPTION
## Related issue 🛠
- closed #286

## Work Description 📝
- 차단 사용자 목록 화면 api 연결
- 차단한 사용자 전체 조회
- 사용자 차단 해제

## Screenshot 📸
[<img src="" width="360"/>
](https://github.com/user-attachments/assets/bef3e8ed-4aaa-4668-96a9-56038a0faeaf)

## Uncompleted Tasks 😅
- N/A

## PR Point 📌

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 차단한 사용자 목록을 조회할 수 있는 기능이 추가되었습니다.
  * 선택한 차단 사용자를 개별적으로 해제(차단 해제)할 수 있는 기능이 추가되었습니다.
  * 차단 목록 UI 흐름과 선택/해제(모달 확인 포함) 동작이 개선되어 즉시 목록에서 변경사항이 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->