### PR TITLE
[feat/#277] ai 답장 api 연동

### DIFF
--- a/app/src/main/java/com/byeboo/app/core/util/DateFormatter.kt
+++ b/app/src/main/java/com/byeboo/app/core/util/DateFormatter.kt
@@ -7,8 +7,10 @@ object DateUtil {
     private val defaultFormatter =
         DateTimeFormatter.ofPattern("yyyy. MM. dd.")
 
-    fun formatToDotDate(createdAt: String): String =
-        LocalDate
-            .parse(createdAt)
-            .format(defaultFormatter)
+    fun formatToDotDate(date: String): String {
+        return runCatching {
+            if (date.isBlank()) return ""
+            LocalDate.parse(date).format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+        }.getOrElse { "" }
+    }
 }

--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestAiAnswerDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestAiAnswerDataSource.kt
@@ -1,0 +1,8 @@
+package com.byeboo.app.data.datasource.remote.quest
+
+import com.byeboo.app.data.dto.base.NullableBaseResponse
+import com.byeboo.app.data.dto.response.quest.QuestAiAnswerResponseDto
+
+interface QuestAiAnswerDataSource {
+    suspend fun postAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto>
+}

--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestAiAnswerDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestAiAnswerDataSource.kt
@@ -5,5 +5,6 @@ import com.byeboo.app.data.dto.response.quest.QuestAiAnswerResponseDto
 
 interface QuestAiAnswerDataSource {
     suspend fun postAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto>
+
     suspend fun getAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto>
 }

--- a/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestAiAnswerDataSource.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasource/remote/quest/QuestAiAnswerDataSource.kt
@@ -5,4 +5,5 @@ import com.byeboo.app.data.dto.response.quest.QuestAiAnswerResponseDto
 
 interface QuestAiAnswerDataSource {
     suspend fun postAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto>
+    suspend fun getAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto>
 }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestAiAnswerDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestAiAnswerDataSourceImpl.kt
@@ -14,6 +14,6 @@ class QuestAiAnswerDataSourceImpl
         override suspend fun postAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto> =
             questAiAnswerService.postAiAnswer(questId = questId)
 
-    override suspend fun getAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto> =
-        questAiAnswerService.getAiAnswer(questId = questId)
+        override suspend fun getAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto> =
+            questAiAnswerService.getAiAnswer(questId = questId)
     }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestAiAnswerDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestAiAnswerDataSourceImpl.kt
@@ -1,0 +1,16 @@
+package com.byeboo.app.data.datasourceimpl.remote.quest
+
+import com.byeboo.app.data.datasource.remote.quest.QuestAiAnswerDataSource
+import com.byeboo.app.data.dto.base.NullableBaseResponse
+import com.byeboo.app.data.dto.response.quest.QuestAiAnswerResponseDto
+import com.byeboo.app.data.service.quest.QuestAiAnswerService
+import javax.inject.Inject
+
+class QuestAiAnswerDataSourceImpl
+    @Inject
+    constructor(
+        private val questAiAnswerService: QuestAiAnswerService,
+    ) : QuestAiAnswerDataSource {
+        override suspend fun postAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto> =
+            questAiAnswerService.postAiAnswer(questId = questId)
+    }

--- a/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestAiAnswerDataSourceImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/datasourceimpl/remote/quest/QuestAiAnswerDataSourceImpl.kt
@@ -13,4 +13,7 @@ class QuestAiAnswerDataSourceImpl
     ) : QuestAiAnswerDataSource {
         override suspend fun postAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto> =
             questAiAnswerService.postAiAnswer(questId = questId)
+
+    override suspend fun getAiAnswer(questId: Long): NullableBaseResponse<QuestAiAnswerResponseDto> =
+        questAiAnswerService.getAiAnswer(questId = questId)
     }

--- a/app/src/main/java/com/byeboo/app/data/di/DataSourceModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/DataSourceModule.kt
@@ -6,6 +6,7 @@ import com.byeboo.app.data.datasource.remote.auth.UserRemoteDataSource
 import com.byeboo.app.data.datasource.remote.fcm.FcmRemoteDataSource
 import com.byeboo.app.data.datasource.remote.offboarding.OffboardingJourneyDataSource
 import com.byeboo.app.data.datasource.remote.offboarding.OffboardingQuestCompletedDataSource
+import com.byeboo.app.data.datasource.remote.quest.QuestAiAnswerDataSource
 import com.byeboo.app.data.datasource.remote.quest.QuestBehaviorDataSource
 import com.byeboo.app.data.datasource.remote.quest.QuestDetailRemoteDataSource
 import com.byeboo.app.data.datasource.remote.quest.QuestInProgressDataSource
@@ -19,6 +20,7 @@ import com.byeboo.app.data.datasourceimpl.remote.auth.UserRemoteDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.fcm.FcmRemoteDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.offboarding.OffboardingJourneyDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.offboarding.OffboardingQuestCompletedDataSourceImpl
+import com.byeboo.app.data.datasourceimpl.remote.quest.QuestAiAnswerDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.quest.QuestBehaviorDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.quest.QuestDetailRemoteDataSourceImpl
 import com.byeboo.app.data.datasourceimpl.remote.quest.QuestInProgressDataSourceImpl
@@ -88,4 +90,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindsFcmRemoteDataSource(impl: FcmRemoteDataSourceImpl): FcmRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsQuestAiAnswerDataSource(impl: QuestAiAnswerDataSourceImpl): QuestAiAnswerDataSource
 }

--- a/app/src/main/java/com/byeboo/app/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/RepositoryModule.kt
@@ -7,6 +7,7 @@ import com.byeboo.app.data.repositoryimpl.auth.UserRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.fcm.FcmTokenRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.offboarding.OffboardingJourneyRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.OffboardingQuestCompletedRepositoryImpl
+import com.byeboo.app.data.repositoryimpl.quest.QuestAiAnswerRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestInProgressRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestRecordedDetailRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestStateRepositoryImpl
@@ -22,6 +23,7 @@ import com.byeboo.app.domain.repository.auth.UserRepository
 import com.byeboo.app.domain.repository.fcm.FcmTokenRepository
 import com.byeboo.app.domain.repository.offboarding.OffboardingJourneyRepository
 import com.byeboo.app.domain.repository.offboarding.OffboardingQuestCompletedRepository
+import com.byeboo.app.domain.repository.quest.QuestAiAnswerRepository
 import com.byeboo.app.domain.repository.quest.QuestBehaviorRepository
 import com.byeboo.app.domain.repository.quest.QuestDetailBehaviorRepository
 import com.byeboo.app.domain.repository.quest.QuestDetailRecordingRepository
@@ -108,4 +110,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindFcmTokenRepository(fcmTokenRepositoryImpl: FcmTokenRepositoryImpl): FcmTokenRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindQuestAiAnswerRepository(questAiAnswerRepositoryImpl: QuestAiAnswerRepositoryImpl): QuestAiAnswerRepository
 }

--- a/app/src/main/java/com/byeboo/app/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/RepositoryModule.kt
@@ -8,8 +8,8 @@ import com.byeboo.app.data.repositoryimpl.fcm.FcmTokenRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.mypage.BlockedUsersRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.offboarding.OffboardingJourneyRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.OffboardingQuestCompletedRepositoryImpl
-import com.byeboo.app.data.repositoryimpl.quest.QuestCommonRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestAiAnswerRepositoryImpl
+import com.byeboo.app.data.repositoryimpl.quest.QuestCommonRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestInProgressRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestRecordedDetailRepositoryImpl
 import com.byeboo.app.data.repositoryimpl.quest.QuestStateRepositoryImpl

--- a/app/src/main/java/com/byeboo/app/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/ServiceModule.kt
@@ -7,6 +7,7 @@ import com.byeboo.app.data.service.auth.UserService
 import com.byeboo.app.data.service.notification.NotificationService
 import com.byeboo.app.data.service.offboarding.OffboardingJourneyService
 import com.byeboo.app.data.service.offboarding.OffboardingQuestCompletedService
+import com.byeboo.app.data.service.quest.QuestAiAnswerService
 import com.byeboo.app.data.service.quest.QuestBehaviorService
 import com.byeboo.app.data.service.quest.QuestDetailService
 import com.byeboo.app.data.service.quest.QuestRecordedDetailService
@@ -107,5 +108,12 @@ object ServiceModule {
     fun providesNotificationService(retrofit: Retrofit): NotificationService =
         retrofit.create(
             NotificationService::class.java,
+        )
+
+    @Provides
+    @Singleton
+    fun providesQuestAiAnswerService(retrofit: Retrofit): QuestAiAnswerService =
+        retrofit.create(
+            QuestAiAnswerService::class.java,
         )
 }

--- a/app/src/main/java/com/byeboo/app/data/dto/response/quest/QuestAiAnswerResponseDto.kt
+++ b/app/src/main/java/com/byeboo/app/data/dto/response/quest/QuestAiAnswerResponseDto.kt
@@ -1,0 +1,10 @@
+package com.byeboo.app.data.dto.response.quest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuestAiAnswerResponseDto(
+    @SerialName("aiAnswer")
+    val aiAnswer: String,
+)

--- a/app/src/main/java/com/byeboo/app/data/mapper/quest/QuestAiAnswewMapper.kt
+++ b/app/src/main/java/com/byeboo/app/data/mapper/quest/QuestAiAnswewMapper.kt
@@ -1,0 +1,9 @@
+package com.byeboo.app.data.mapper.quest
+
+import com.byeboo.app.data.dto.response.quest.QuestAiAnswerResponseDto
+import com.byeboo.app.domain.model.quest.QuestAiAnswerModel
+
+fun QuestAiAnswerResponseDto.toDomain(): QuestAiAnswerModel =
+    QuestAiAnswerModel(
+        aiAnswer = this.aiAnswer,
+    )

--- a/app/src/main/java/com/byeboo/app/data/mapper/quest/QuestRecordedDetailMapper.kt
+++ b/app/src/main/java/com/byeboo/app/data/mapper/quest/QuestRecordedDetailMapper.kt
@@ -14,5 +14,5 @@ fun QuestRecordedDetailResponseDto.toDomain(): QuestRecordedDetailModel =
         imageKey = this.imageKey,
         imageUrl = this.imageUrl,
         emotionDescription = this.emotionDescription,
-        aiAnswerExists = this.aiAnswerExists,
+        isExistedAiAnswer = this.aiAnswerExists,
     )

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestAiAnswerRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestAiAnswerRepositoryImpl.kt
@@ -15,4 +15,9 @@ class QuestAiAnswerRepositoryImpl
             runCatching {
                 questAiAnswerDataSource.postAiAnswer(questId = questId).data?.toDomain() ?: throw IllegalStateException()
             }
+
+    override suspend fun getAiAnswer(questId: Long): Result<QuestAiAnswerModel> =
+        runCatching{
+            questAiAnswerDataSource.getAiAnswer(questId = questId).data?.toDomain() ?: throw IllegalStateException()
+        }
     }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestAiAnswerRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestAiAnswerRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.byeboo.app.data.repositoryimpl.quest
+
+import com.byeboo.app.data.datasource.remote.quest.QuestAiAnswerDataSource
+import com.byeboo.app.data.mapper.quest.toDomain
+import com.byeboo.app.domain.model.quest.QuestAiAnswerModel
+import com.byeboo.app.domain.repository.quest.QuestAiAnswerRepository
+import javax.inject.Inject
+
+class QuestAiAnswerRepositoryImpl
+    @Inject
+    constructor(
+        private val questAiAnswerDataSource: QuestAiAnswerDataSource,
+    ) : QuestAiAnswerRepository {
+        override suspend fun postAiAnswer(questId: Long): Result<QuestAiAnswerModel> =
+            runCatching {
+                questAiAnswerDataSource.postAiAnswer(questId = questId).data?.toDomain() ?: throw IllegalStateException()
+            }
+    }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestAiAnswerRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/quest/QuestAiAnswerRepositoryImpl.kt
@@ -16,8 +16,8 @@ class QuestAiAnswerRepositoryImpl
                 questAiAnswerDataSource.postAiAnswer(questId = questId).data?.toDomain() ?: throw IllegalStateException()
             }
 
-    override suspend fun getAiAnswer(questId: Long): Result<QuestAiAnswerModel> =
-        runCatching{
-            questAiAnswerDataSource.getAiAnswer(questId = questId).data?.toDomain() ?: throw IllegalStateException()
-        }
+        override suspend fun getAiAnswer(questId: Long): Result<QuestAiAnswerModel> =
+            runCatching {
+                questAiAnswerDataSource.getAiAnswer(questId = questId).data?.toDomain() ?: throw IllegalStateException()
+            }
     }

--- a/app/src/main/java/com/byeboo/app/data/service/quest/QuestAiAnswerService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/quest/QuestAiAnswerService.kt
@@ -1,0 +1,13 @@
+package com.byeboo.app.data.service.quest
+
+import com.byeboo.app.data.dto.base.NullableBaseResponse
+import com.byeboo.app.data.dto.response.quest.QuestAiAnswerResponseDto
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface QuestAiAnswerService {
+    @POST("/api/v1/quests/{questId}/ai-answer")
+    suspend fun postAiAnswer(
+        @Path("questId") questId: Long,
+    ): NullableBaseResponse<QuestAiAnswerResponseDto>
+}

--- a/app/src/main/java/com/byeboo/app/data/service/quest/QuestAiAnswerService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/quest/QuestAiAnswerService.kt
@@ -2,12 +2,18 @@ package com.byeboo.app.data.service.quest
 
 import com.byeboo.app.data.dto.base.NullableBaseResponse
 import com.byeboo.app.data.dto.response.quest.QuestAiAnswerResponseDto
+import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface QuestAiAnswerService {
     @POST("/api/v1/quests/{questId}/ai-answer")
     suspend fun postAiAnswer(
+        @Path("questId") questId: Long,
+    ): NullableBaseResponse<QuestAiAnswerResponseDto>
+
+    @GET("/api/v1/quests/{questId}/ai-answer ")
+    suspend fun getAiAnswer(
         @Path("questId") questId: Long,
     ): NullableBaseResponse<QuestAiAnswerResponseDto>
 }

--- a/app/src/main/java/com/byeboo/app/data/service/quest/QuestAiAnswerService.kt
+++ b/app/src/main/java/com/byeboo/app/data/service/quest/QuestAiAnswerService.kt
@@ -12,7 +12,7 @@ interface QuestAiAnswerService {
         @Path("questId") questId: Long,
     ): NullableBaseResponse<QuestAiAnswerResponseDto>
 
-    @GET("/api/v1/quests/{questId}/ai-answer ")
+    @GET("/api/v1/quests/{questId}/ai-answer")
     suspend fun getAiAnswer(
         @Path("questId") questId: Long,
     ): NullableBaseResponse<QuestAiAnswerResponseDto>

--- a/app/src/main/java/com/byeboo/app/domain/model/quest/QuestAiAnswerModel.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/quest/QuestAiAnswerModel.kt
@@ -1,0 +1,5 @@
+package com.byeboo.app.domain.model.quest
+
+data class QuestAiAnswerModel(
+    val aiAnswer: String,
+)

--- a/app/src/main/java/com/byeboo/app/domain/model/quest/QuestDataModel.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/quest/QuestDataModel.kt
@@ -1,6 +1,6 @@
 package com.byeboo.app.domain.model.quest
 
-data class QuestData(
+data class QuestDataModel(
     val inProgressQuest: QuestInProgressModel,
     val journeyTitle: String,
     val questCompletedCount: Long,

--- a/app/src/main/java/com/byeboo/app/domain/model/quest/QuestRecordedDetailModel.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/quest/QuestRecordedDetailModel.kt
@@ -10,5 +10,5 @@ data class QuestRecordedDetailModel(
     val imageKey: String? = null,
     val imageUrl: String? = null,
     val emotionDescription: String,
-    val aiAnswerExists: Boolean,
+    val isExistedAiAnswer: Boolean,
 )

--- a/app/src/main/java/com/byeboo/app/domain/model/quest/QuestValidator.kt
+++ b/app/src/main/java/com/byeboo/app/domain/model/quest/QuestValidator.kt
@@ -1,5 +1,0 @@
-package com.byeboo.app.domain.model.quest
-
-object QuestValidator {
-    fun validButton(imageCount: Int): Boolean = imageCount > 0
-}

--- a/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestAiAnswerRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestAiAnswerRepository.kt
@@ -4,4 +4,5 @@ import com.byeboo.app.domain.model.quest.QuestAiAnswerModel
 
 interface QuestAiAnswerRepository {
     suspend fun postAiAnswer(questId: Long): Result<QuestAiAnswerModel>
+    suspend fun getAiAnswer(questId: Long): Result<QuestAiAnswerModel>
 }

--- a/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestAiAnswerRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestAiAnswerRepository.kt
@@ -1,0 +1,7 @@
+package com.byeboo.app.domain.repository.quest
+
+import com.byeboo.app.domain.model.quest.QuestAiAnswerModel
+
+interface QuestAiAnswerRepository {
+    suspend fun postAiAnswer(questId: Long): Result<QuestAiAnswerModel>
+}

--- a/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestAiAnswerRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/quest/QuestAiAnswerRepository.kt
@@ -4,5 +4,6 @@ import com.byeboo.app.domain.model.quest.QuestAiAnswerModel
 
 interface QuestAiAnswerRepository {
     suspend fun postAiAnswer(questId: Long): Result<QuestAiAnswerModel>
+
     suspend fun getAiAnswer(questId: Long): Result<QuestAiAnswerModel>
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/quest/GetAiAnswerUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/quest/GetAiAnswerUseCase.kt
@@ -1,0 +1,13 @@
+package com.byeboo.app.domain.usecase.quest
+
+import com.byeboo.app.domain.model.quest.QuestAiAnswerModel
+import com.byeboo.app.domain.repository.quest.QuestAiAnswerRepository
+import javax.inject.Inject
+
+class GetAiAnswerUseCase
+    @Inject
+    constructor(
+        private val questAiAnswerRepository: QuestAiAnswerRepository,
+    ) {
+        suspend operator fun invoke(questId: Long): Result<QuestAiAnswerModel> = questAiAnswerRepository.getAiAnswer(questId = questId)
+    }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/quest/PostAiAnswerUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/quest/PostAiAnswerUseCase.kt
@@ -1,0 +1,13 @@
+package com.byeboo.app.domain.usecase.quest
+
+import com.byeboo.app.domain.model.quest.QuestAiAnswerModel
+import com.byeboo.app.domain.repository.quest.QuestAiAnswerRepository
+import javax.inject.Inject
+
+class PostAiAnswerUseCase
+    @Inject
+    constructor(
+        private val questAiAnswerRepository: QuestAiAnswerRepository,
+    ) {
+        suspend operator fun invoke(questId: Long): Result<QuestAiAnswerModel> = questAiAnswerRepository.postAiAnswer(questId = questId)
+    }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/quest/QuestUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/quest/QuestUseCase.kt
@@ -1,6 +1,6 @@
-package com.byeboo.app.domain.usecase
+package com.byeboo.app.domain.usecase.quest
 
-import com.byeboo.app.domain.model.quest.QuestData
+import com.byeboo.app.domain.model.quest.QuestDataModel
 import com.byeboo.app.domain.repository.quest.QuestInProgressRepository
 import com.byeboo.app.domain.repository.quest.QuestStateRepository
 import javax.inject.Inject
@@ -11,11 +11,11 @@ class QuestUseCase
         private val questInProgressRepository: QuestInProgressRepository,
         private val questStateRepository: QuestStateRepository,
     ) {
-        suspend operator fun invoke(): QuestData {
+        suspend operator fun invoke(): QuestDataModel {
             val result = questInProgressRepository.getInProgressQuest().getOrThrow()
             val journey = questStateRepository.getUserJourney().orEmpty()
             val questCompletedCount = questStateRepository.getQuestCount().getOrNull()?.count ?: 0L
-            return QuestData(
+            return QuestDataModel(
                 inProgressQuest = result,
                 journeyTitle = journey,
                 questCompletedCount = questCompletedCount,

--- a/app/src/main/java/com/byeboo/app/domain/usecase/quest/UploadImageUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/quest/UploadImageUseCase.kt
@@ -1,4 +1,4 @@
-package com.byeboo.app.domain.usecase
+package com.byeboo.app.domain.usecase.quest
 
 import com.byeboo.app.domain.model.quest.BehaviorAnswerRequestModel
 import com.byeboo.app.domain.model.quest.QuestBehaviorEditModel

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -158,10 +158,11 @@ fun MainNavHost(
                 navigator.navigateToQuestCommonWriting(questId = questId)
             },
             navigateUp = navigator::navigateUp,
-            navigateToQuestAiAnswer = { questId, isExistedAiAnswer ->
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerEntryPoint ->
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,
+                    aiAnswerEntryPoint = aiAnswerEntryPoint,
                     navOptions = clearStackNavOptions,
                 )
             },
@@ -234,10 +235,11 @@ fun MainNavHost(
                     navOptions = keepStackNavOptions,
                 )
             },
-            navigateToQuestAiAnswer = { questId, isExistedAiAnswer ->
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerEntryPoint ->
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,
+                    aiAnswerEntryPoint = aiAnswerEntryPoint,
                     navOptions = clearStackNavOptions,
                 )
             },

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -158,6 +158,13 @@ fun MainNavHost(
                 navigator.navigateToQuestCommonWriting(questId = questId)
             },
             navigateUp = navigator::navigateUp,
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer ->
+                navigator.navigateToQuestAiAnswer(
+                    questId = questId,
+                    isExistedAiAnswer = isExistedAiAnswer,
+                    navOptions = clearStackNavOptions,
+                )
+            },
             paddingValues = paddingValues,
         )
 
@@ -225,6 +232,13 @@ fun MainNavHost(
                     fromOffboarding = fromOffboarding,
                     imageKey = imageKey,
                     navOptions = keepStackNavOptions,
+                )
+            },
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer ->
+                navigator.navigateToQuestAiAnswer(
+                    questId = questId,
+                    isExistedAiAnswer = isExistedAiAnswer,
+                    navOptions = clearStackNavOptions,
                 )
             },
             paddingValues = paddingValues,

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -11,6 +11,7 @@ import com.byeboo.app.presentation.auth.navigation.authGraph
 import com.byeboo.app.presentation.home.navigation.Home
 import com.byeboo.app.presentation.home.navigation.homeGraph
 import com.byeboo.app.presentation.mypage.navigation.myPageGraph
+import com.byeboo.app.presentation.offboarding.navigation.OffboardingQuestReview
 import com.byeboo.app.presentation.offboarding.navigation.offboardingGraph
 import com.byeboo.app.presentation.quest.navigation.questGraph
 import com.byeboo.app.presentation.splash.navigation.splashGraph
@@ -41,6 +42,14 @@ fun MainNavHost(
         navOptions {
             launchSingleTop = true
             restoreState = true
+        }
+    val offboardingReviewToAiNavOptions =
+        navOptions {
+            popUpTo(OffboardingQuestReview) {
+                inclusive = true
+            }
+            launchSingleTop = true
+            restoreState = false
         }
 
     NavHost(
@@ -162,7 +171,13 @@ fun MainNavHost(
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,
-                    aiAnswerEntryPoint = aiAnswerEntryPoint,
+                    aiAnswerOrigin = aiAnswerEntryPoint,
+                    navOptions = clearStackNavOptions,
+                )
+            },
+            navigateToOffboardingQuestCompleted = { questType ->
+                navigator.navigateToOffboardingQuestCompleted(
+                    questType = questType,
                     navOptions = clearStackNavOptions,
                 )
             },
@@ -239,8 +254,8 @@ fun MainNavHost(
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,
-                    aiAnswerEntryPoint = aiAnswerEntryPoint,
-                    navOptions = clearStackNavOptions,
+                    aiAnswerOrigin = aiAnswerEntryPoint,
+                    navOptions = offboardingReviewToAiNavOptions,
                 )
             },
             paddingValues = paddingValues,

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -250,7 +250,7 @@ fun MainNavHost(
                     navOptions = keepStackNavOptions,
                 )
             },
-            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerOrigin, questType->
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerOrigin, questType ->
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -45,7 +45,7 @@ fun MainNavHost(
         }
     val offboardingReviewToAiNavOptions =
         navOptions {
-            popUpTo(OffboardingQuestReview) {
+            popUpTo<OffboardingQuestReview> {
                 inclusive = true
             }
             launchSingleTop = true
@@ -167,11 +167,11 @@ fun MainNavHost(
                 navigator.navigateToQuestCommonWriting(questId = questId)
             },
             navigateUp = navigator::navigateUp,
-            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerEntryPoint ->
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerOrigin ->
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,
-                    aiAnswerOrigin = aiAnswerEntryPoint,
+                    aiAnswerOrigin = aiAnswerOrigin,
                     navOptions = clearStackNavOptions,
                 )
             },
@@ -250,11 +250,12 @@ fun MainNavHost(
                     navOptions = keepStackNavOptions,
                 )
             },
-            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerEntryPoint ->
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerOrigin, questType->
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,
-                    aiAnswerOrigin = aiAnswerEntryPoint,
+                    aiAnswerOrigin = aiAnswerOrigin,
+                    questType = questType,
                     navOptions = offboardingReviewToAiNavOptions,
                 )
             },

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavHost.kt
@@ -175,12 +175,6 @@ fun MainNavHost(
                     navOptions = clearStackNavOptions,
                 )
             },
-            navigateToOffboardingQuestCompleted = { questType ->
-                navigator.navigateToOffboardingQuestCompleted(
-                    questType = questType,
-                    navOptions = clearStackNavOptions,
-                )
-            },
             paddingValues = paddingValues,
         )
 
@@ -250,12 +244,11 @@ fun MainNavHost(
                     navOptions = keepStackNavOptions,
                 )
             },
-            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerOrigin, questType ->
+            navigateToQuestAiAnswer = { questId, isExistedAiAnswer, aiAnswerOrigin ->
                 navigator.navigateToQuestAiAnswer(
                     questId = questId,
                     isExistedAiAnswer = isExistedAiAnswer,
                     aiAnswerOrigin = aiAnswerOrigin,
-                    questType = questType,
                     navOptions = offboardingReviewToAiNavOptions,
                 )
             },

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
@@ -28,6 +28,7 @@ import com.byeboo.app.presentation.quest.behavior.navigation.navigateToQuestBeha
 import com.byeboo.app.presentation.quest.behavior.navigation.navigateToQuestBehaviorComplete
 import com.byeboo.app.presentation.quest.common.navigation.navigateToQuestCommonComplete
 import com.byeboo.app.presentation.quest.common.navigation.navigateToQuestCommonWriting
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import com.byeboo.app.presentation.quest.navigation.Quest
 import com.byeboo.app.presentation.quest.navigation.navigateToQuest
 import com.byeboo.app.presentation.quest.navigation.navigateToQuestAiAnswer
@@ -245,9 +246,15 @@ class MainNavigator(
     fun navigateToQuestAiAnswer(
         questId: Long,
         isExistedAiAnswer: Boolean,
+        aiAnswerEntryPoint: AiAnswerEntryPoint,
         navOptions: NavOptions? = null,
     ) {
-        navController.navigateToQuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, navOptions = navOptions)
+        navController.navigateToQuestAiAnswer(
+            questId = questId,
+            isExistedAiAnswer = isExistedAiAnswer,
+            aiAnswerEntryPoint = aiAnswerEntryPoint,
+            navOptions = navOptions,
+        )
     }
 
     fun navigateToMyPage(navOptions: NavOptions? = null) {

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
@@ -247,14 +247,12 @@ class MainNavigator(
         questId: Long,
         isExistedAiAnswer: Boolean,
         aiAnswerOrigin: AiAnswerOrigin,
-        questType: QuestType? = null,
         navOptions: NavOptions? = null,
     ) {
         navController.navigateToQuestAiAnswer(
             questId = questId,
             isExistedAiAnswer = isExistedAiAnswer,
             aiAnswerOrigin = aiAnswerOrigin,
-            questType = questType,
             navOptions = navOptions,
         )
     }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
@@ -247,12 +247,14 @@ class MainNavigator(
         questId: Long,
         isExistedAiAnswer: Boolean,
         aiAnswerOrigin: AiAnswerOrigin,
+        questType: QuestType? = null,
         navOptions: NavOptions? = null,
     ) {
         navController.navigateToQuestAiAnswer(
             questId = questId,
             isExistedAiAnswer = isExistedAiAnswer,
             aiAnswerOrigin = aiAnswerOrigin,
+            questType = questType,
             navOptions = navOptions,
         )
     }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
@@ -30,6 +30,7 @@ import com.byeboo.app.presentation.quest.common.navigation.navigateToQuestCommon
 import com.byeboo.app.presentation.quest.common.navigation.navigateToQuestCommonWriting
 import com.byeboo.app.presentation.quest.navigation.Quest
 import com.byeboo.app.presentation.quest.navigation.navigateToQuest
+import com.byeboo.app.presentation.quest.navigation.navigateToQuestAiAnswer
 import com.byeboo.app.presentation.quest.navigation.navigateToQuestCommonAnswer
 import com.byeboo.app.presentation.quest.navigation.navigateToQuestMyAnswerDetail
 import com.byeboo.app.presentation.quest.navigation.navigateToQuestMyAnswers
@@ -239,6 +240,14 @@ class MainNavigator(
         navOptions: NavOptions? = null,
     ) {
         navController.navigateToQuestReview(questId = questId, navOptions = navOptions)
+    }
+
+    fun navigateToQuestAiAnswer(
+        questId: Long,
+        isExistedAiAnswer: Boolean,
+        navOptions: NavOptions? = null,
+    ) {
+        navController.navigateToQuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, navOptions = navOptions)
     }
 
     fun navigateToMyPage(navOptions: NavOptions? = null) {

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainNavigator.kt
@@ -28,7 +28,7 @@ import com.byeboo.app.presentation.quest.behavior.navigation.navigateToQuestBeha
 import com.byeboo.app.presentation.quest.behavior.navigation.navigateToQuestBehaviorComplete
 import com.byeboo.app.presentation.quest.common.navigation.navigateToQuestCommonComplete
 import com.byeboo.app.presentation.quest.common.navigation.navigateToQuestCommonWriting
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import com.byeboo.app.presentation.quest.navigation.Quest
 import com.byeboo.app.presentation.quest.navigation.navigateToQuest
 import com.byeboo.app.presentation.quest.navigation.navigateToQuestAiAnswer
@@ -246,13 +246,13 @@ class MainNavigator(
     fun navigateToQuestAiAnswer(
         questId: Long,
         isExistedAiAnswer: Boolean,
-        aiAnswerEntryPoint: AiAnswerEntryPoint,
+        aiAnswerOrigin: AiAnswerOrigin,
         navOptions: NavOptions? = null,
     ) {
         navController.navigateToQuestAiAnswer(
             questId = questId,
             isExistedAiAnswer = isExistedAiAnswer,
-            aiAnswerEntryPoint = aiAnswerEntryPoint,
+            aiAnswerOrigin = aiAnswerOrigin,
             navOptions = navOptions,
         )
     }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
@@ -53,7 +53,7 @@ fun NavGraphBuilder.offboardingGraph(
     navigateToOffboardingQuestCompletedFromReview: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin, QuestType) -> Unit,
     paddingValues: PaddingValues,
 ) {
     composable<OffboardingCompletedGuide> {

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
@@ -52,6 +52,7 @@ fun NavGraphBuilder.offboardingGraph(
     navigateToOffboardingQuestCompletedFromReview: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     paddingValues: PaddingValues,
 ) {
     composable<OffboardingCompletedGuide> {
@@ -93,6 +94,7 @@ fun NavGraphBuilder.offboardingGraph(
             navigateToOffboardingQuestCompleted = navigateToOffboardingQuestCompletedFromReview,
             navigateToQuestRecordingEdit = navigateToQuestRecordingEdit,
             navigateToQuestBehaviorEdit = navigateToQuestBehaviorEdit,
+            navigateToQuestAiAnswer = navigateToQuestAiAnswer,
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
@@ -12,6 +12,7 @@ import com.byeboo.app.presentation.offboarding.offboardingcompletedjourney.Offbo
 import com.byeboo.app.presentation.offboarding.offboardingnewjourney.OffboardingNewJourneyRoute
 import com.byeboo.app.presentation.offboarding.offboardingquestcompleted.OffboardingQuestCompletedRoute
 import com.byeboo.app.presentation.offboarding.offboardingquestreview.OffboardingQuestReviewRoute
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import kotlinx.serialization.Serializable
 
 fun NavController.navigateToOffboardingCompletedGuide(navOptions: NavOptions? = null) {
@@ -52,7 +53,7 @@ fun NavGraphBuilder.offboardingGraph(
     navigateToOffboardingQuestCompletedFromReview: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     paddingValues: PaddingValues,
 ) {
     composable<OffboardingCompletedGuide> {
@@ -116,5 +117,5 @@ data class OffboardingQuestCompleted(
 @Serializable
 data class OffboardingQuestReview(
     val questId: Long,
-    val journeyType: QuestType,
+    val questType: QuestType,
 ) : Route

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
@@ -12,7 +12,7 @@ import com.byeboo.app.presentation.offboarding.offboardingcompletedjourney.Offbo
 import com.byeboo.app.presentation.offboarding.offboardingnewjourney.OffboardingNewJourneyRoute
 import com.byeboo.app.presentation.offboarding.offboardingquestcompleted.OffboardingQuestCompletedRoute
 import com.byeboo.app.presentation.offboarding.offboardingquestreview.OffboardingQuestReviewRoute
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import kotlinx.serialization.Serializable
 
 fun NavController.navigateToOffboardingCompletedGuide(navOptions: NavOptions? = null) {
@@ -53,7 +53,7 @@ fun NavGraphBuilder.offboardingGraph(
     navigateToOffboardingQuestCompletedFromReview: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     paddingValues: PaddingValues,
 ) {
     composable<OffboardingCompletedGuide> {

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/navigation/OffboardingNavigation.kt
@@ -53,7 +53,7 @@ fun NavGraphBuilder.offboardingGraph(
     navigateToOffboardingQuestCompletedFromReview: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin, QuestType) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     paddingValues: PaddingValues,
 ) {
     composable<OffboardingCompletedGuide> {

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestcompleted/OffboardingQuestCompletedViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestcompleted/OffboardingQuestCompletedViewModel.kt
@@ -52,9 +52,8 @@ class OffboardingQuestCompletedViewModel
             nickname: String,
         ) {
             viewModelScope.launch {
-                val result = offboardingQuestCompletedRepository.getCompletedQuest(journey)
-
-                result
+                offboardingQuestCompletedRepository
+                    .getCompletedQuest(journey)
                     .onSuccess { detail ->
                         _uiState.update { detail.toUiState(journey = journey, nickname = nickname) }
                     }.onFailure {

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
@@ -83,7 +83,7 @@ fun OffboardingQuestReviewRoute(
                         effect.questId,
                         effect.isExistedAiAnswer,
                         effect.aiAnswerOrigin,
-                        effect.questType
+                        effect.questType,
                     )
                 is OffboardingQuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
@@ -42,6 +42,7 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import com.byeboo.app.presentation.quest.review.my.component.QuestReviewTopbar
 import kotlinx.coroutines.flow.collectLatest
 
@@ -51,7 +52,7 @@ fun OffboardingQuestReviewRoute(
     navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     viewModel: OffboardingQuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -81,6 +82,7 @@ fun OffboardingQuestReviewRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
+                        effect.aiAnswerEntryPoint,
                     )
                 is OffboardingQuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
@@ -89,6 +89,7 @@ fun OffboardingQuestReviewRoute(
         paddingValues = paddingValues,
         onEditClick = { viewModel.onEditClicked(uiState.questType) },
         onBackClick = viewModel::onBackClicked,
+        onAiAnswerClick = viewModel::onAiAnswerClicked,
     )
 }
 
@@ -98,6 +99,7 @@ private fun OffboardingQuestReviewScreen(
     paddingValues: PaddingValues,
     onEditClick: () -> Unit,
     onBackClick: () -> Unit,
+    onAiAnswerClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -193,11 +195,11 @@ private fun OffboardingQuestReviewScreen(
                         Spacer(modifier = Modifier.height(screenHeightDp(20.dp)))
 
                         ByeBooButton(
-                            buttonText = "보리에게 답장 받기",
+                            buttonText = if (uiState.isExistedAiAnswer) "보리의 답장 보러가기" else "보리에게 답장받기",
                             buttonTextColor = ByeBooTheme.colors.white,
                             buttonStyle = ByeBooTheme.typography.body2,
                             buttonBackgroundColor = ByeBooTheme.colors.primary300,
-                            onClick = { /*Todo: ai 버튼 연결 */ },
+                            onClick = onAiAnswerClick,
                         )
                     }
                 }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
@@ -52,7 +52,7 @@ fun OffboardingQuestReviewRoute(
     navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin, QuestType) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     viewModel: OffboardingQuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -83,7 +83,6 @@ fun OffboardingQuestReviewRoute(
                         effect.questId,
                         effect.isExistedAiAnswer,
                         effect.aiAnswerOrigin,
-                        effect.questType,
                     )
                 is OffboardingQuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
@@ -52,7 +52,7 @@ fun OffboardingQuestReviewRoute(
     navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin, QuestType) -> Unit,
     viewModel: OffboardingQuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -83,6 +83,7 @@ fun OffboardingQuestReviewRoute(
                         effect.questId,
                         effect.isExistedAiAnswer,
                         effect.aiAnswerOrigin,
+                        effect.questType
                     )
                 is OffboardingQuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.SubcomposeAsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
+import com.byeboo.app.core.designsystem.component.LoadingScreen
 import com.byeboo.app.core.designsystem.component.button.ByeBooButton
 import com.byeboo.app.core.designsystem.component.text.ContentText
 import com.byeboo.app.core.designsystem.event.LocalSnackBarTrigger
@@ -50,6 +51,7 @@ fun OffboardingQuestReviewRoute(
     navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     viewModel: OffboardingQuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -75,6 +77,11 @@ fun OffboardingQuestReviewRoute(
                         true,
                         effect.imageKey,
                     )
+                is OffboardingQuestReviewSideEffect.NavigateToQuestAiAnswer ->
+                    navigateToQuestAiAnswer(
+                        effect.questId,
+                        effect.isExistedAiAnswer,
+                    )
                 is OffboardingQuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }
         }
@@ -84,13 +91,17 @@ fun OffboardingQuestReviewRoute(
         viewModel.onBackClicked()
     }
 
-    OffboardingQuestReviewScreen(
-        uiState = uiState,
-        paddingValues = paddingValues,
-        onEditClick = { viewModel.onEditClicked(uiState.questType) },
-        onBackClick = viewModel::onBackClicked,
-        onAiAnswerClick = viewModel::onAiAnswerClicked,
-    )
+    if (uiState.isLoading) {
+        LoadingScreen()
+    } else {
+        OffboardingQuestReviewScreen(
+            uiState = uiState,
+            paddingValues = paddingValues,
+            onEditClick = { viewModel.onEditClicked(uiState.questType) },
+            onBackClick = viewModel::onBackClicked,
+            onAiAnswerClick = viewModel::onAiAnswerClicked,
+        )
+    }
 }
 
 @Composable
@@ -130,7 +141,7 @@ private fun OffboardingQuestReviewScreen(
                     PaddingValues(
                         start = screenWidthDp(24.dp),
                         end = screenWidthDp(24.dp),
-                        bottom = screenHeightDp(28.dp),
+                        bottom = if (canScroll) screenHeightDp(28.dp) else screenHeightDp(90.dp),
                     ),
             ) {
                 item {
@@ -145,7 +156,9 @@ private fun OffboardingQuestReviewScreen(
                 }
 
                 if (uiState.imageUrl.isNullOrBlank()) {
-                    item { ContentText(text = uiState.answer) }
+                    item {
+                        ContentText(text = uiState.answer)
+                    }
                 } else {
                     item {
                         Column(
@@ -170,10 +183,13 @@ private fun OffboardingQuestReviewScreen(
                                     Box(
                                         modifier = Modifier.fillMaxSize(),
                                         contentAlignment = Alignment.Center,
-                                    ) { CircularProgressIndicator() }
+                                    ) {
+                                        CircularProgressIndicator()
+                                    }
                                 },
                             )
                         }
+
                         if (uiState.answer.isNotBlank()) {
                             Spacer(modifier = Modifier.height(screenHeightDp(20.dp)))
                             ContentText(uiState.answer)
@@ -203,6 +219,21 @@ private fun OffboardingQuestReviewScreen(
                         )
                     }
                 }
+            }
+
+            if (!canScroll) {
+                ByeBooButton(
+                    buttonText = if (uiState.isExistedAiAnswer) "보리의 답장 보러가기" else "보리에게 답장받기",
+                    buttonTextColor = ByeBooTheme.colors.white,
+                    buttonStyle = ByeBooTheme.typography.body2,
+                    buttonBackgroundColor = ByeBooTheme.colors.primary300,
+                    onClick = onAiAnswerClick,
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(horizontal = screenWidthDp(24.dp))
+                            .padding(bottom = screenHeightDp(10.dp)),
+                )
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewScreen.kt
@@ -42,7 +42,7 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import com.byeboo.app.presentation.quest.review.my.component.QuestReviewTopbar
 import kotlinx.coroutines.flow.collectLatest
 
@@ -52,7 +52,7 @@ fun OffboardingQuestReviewRoute(
     navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     viewModel: OffboardingQuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -82,7 +82,7 @@ fun OffboardingQuestReviewRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
-                        effect.aiAnswerEntryPoint,
+                        effect.aiAnswerOrigin,
                     )
                 is OffboardingQuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
@@ -6,7 +6,7 @@ import com.byeboo.app.core.model.quest.QuestType
 import java.time.LocalDate
 
 data class OffboardingQuestReviewState(
-    val questId: Long = 0,
+    val isLoading: Boolean = true,
     val stepNumber: Long = 0,
     val questNumber: Long = 0,
     val createdAt: String = LocalDate.now().toString(),
@@ -37,6 +37,11 @@ sealed interface OffboardingQuestReviewSideEffect {
         val isEditMode: Boolean,
         val fromOffboarding: Boolean,
         val imageKey: String,
+    ) : OffboardingQuestReviewSideEffect
+
+    data class NavigateToQuestAiAnswer(
+        val questId: Long,
+        val isExistedAiAnswer: Boolean,
     ) : OffboardingQuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
@@ -3,7 +3,7 @@ package com.byeboo.app.presentation.offboarding.offboardingquestreview
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import java.time.LocalDate
 
 data class OffboardingQuestReviewState(
@@ -43,7 +43,7 @@ sealed interface OffboardingQuestReviewSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
-        val aiAnswerEntryPoint: AiAnswerEntryPoint,
+        val aiAnswerOrigin: AiAnswerOrigin,
     ) : OffboardingQuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.presentation.offboarding.offboardingquestreview
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import java.time.LocalDate
 
 data class OffboardingQuestReviewState(
@@ -42,6 +43,7 @@ sealed interface OffboardingQuestReviewSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
+        val aiAnswerEntryPoint: AiAnswerEntryPoint,
     ) : OffboardingQuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
@@ -18,6 +18,7 @@ data class OffboardingQuestReviewState(
     val emotionDescription: String = "",
     val selectedEmotion: EmotionChipType = EmotionChipType.EMOTION_NEUTRAL,
     val questType: QuestType = QuestType.RECORDING,
+    val isExistedAiAnswer: Boolean = false,
 )
 
 sealed interface OffboardingQuestReviewSideEffect {

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
@@ -44,6 +44,7 @@ sealed interface OffboardingQuestReviewSideEffect {
         val questId: Long,
         val isExistedAiAnswer: Boolean,
         val aiAnswerOrigin: AiAnswerOrigin,
+        val questType: QuestType,
     ) : OffboardingQuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewState.kt
@@ -44,7 +44,6 @@ sealed interface OffboardingQuestReviewSideEffect {
         val questId: Long,
         val isExistedAiAnswer: Boolean,
         val aiAnswerOrigin: AiAnswerOrigin,
-        val questType: QuestType,
     ) : OffboardingQuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
@@ -9,6 +9,7 @@ import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
 import com.byeboo.app.presentation.offboarding.navigation.OffboardingQuestReview
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,7 +30,7 @@ class OffboardingQuestReviewViewModel
         savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
         private val questIdArg = savedStateHandle.toRoute<OffboardingQuestReview>().questId
-        private val journeyTypeArg = savedStateHandle.toRoute<OffboardingQuestReview>().journeyType
+        private val journeyTypeArg = savedStateHandle.toRoute<OffboardingQuestReview>().questType
         private val _uiState = MutableStateFlow(OffboardingQuestReviewState())
         val uiState: StateFlow<OffboardingQuestReviewState> = _uiState.asStateFlow()
 
@@ -128,6 +129,7 @@ class OffboardingQuestReviewViewModel
                     OffboardingQuestReviewSideEffect.NavigateToQuestAiAnswer(
                         questId = questIdArg,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                        aiAnswerEntryPoint = AiAnswerEntryPoint.OFFBOARDING,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
@@ -9,7 +9,7 @@ import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
 import com.byeboo.app.presentation.offboarding.navigation.OffboardingQuestReview
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,7 +30,7 @@ class OffboardingQuestReviewViewModel
         savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
         private val questIdArg = savedStateHandle.toRoute<OffboardingQuestReview>().questId
-        private val journeyTypeArg = savedStateHandle.toRoute<OffboardingQuestReview>().questType
+        private val questTypeArg = savedStateHandle.toRoute<OffboardingQuestReview>().questType
         private val _uiState = MutableStateFlow(OffboardingQuestReviewState())
         val uiState: StateFlow<OffboardingQuestReviewState> = _uiState.asStateFlow()
 
@@ -71,7 +71,7 @@ class OffboardingQuestReviewViewModel
             viewModelScope.launch {
                 _sideEffect.emit(
                     OffboardingQuestReviewSideEffect.NavigateToOffboardingQuestCompleted(
-                        journey = journeyTypeArg,
+                        journey = questTypeArg,
                     ),
                 )
             }
@@ -129,7 +129,7 @@ class OffboardingQuestReviewViewModel
                     OffboardingQuestReviewSideEffect.NavigateToQuestAiAnswer(
                         questId = questIdArg,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
-                        aiAnswerEntryPoint = AiAnswerEntryPoint.OFFBOARDING,
+                        aiAnswerOrigin = AiAnswerOrigin.Offboarding(questType = questTypeArg),
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
@@ -15,6 +16,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -28,18 +30,11 @@ class OffboardingQuestReviewViewModel
     ) : ViewModel() {
         private val questIdArg = savedStateHandle.toRoute<OffboardingQuestReview>().questId
         private val journeyTypeArg = savedStateHandle.toRoute<OffboardingQuestReview>().journeyType
-        private val _uiState =
-            MutableStateFlow(
-                OffboardingQuestReviewState(
-                    questId = questIdArg,
-                ),
-            )
-        val uiState: StateFlow<OffboardingQuestReviewState>
-            get() = _uiState.asStateFlow()
+        private val _uiState = MutableStateFlow(OffboardingQuestReviewState())
+        val uiState: StateFlow<OffboardingQuestReviewState> = _uiState.asStateFlow()
 
         private val _sideEffect = MutableSharedFlow<OffboardingQuestReviewSideEffect>()
-        val sideEffect: SharedFlow<OffboardingQuestReviewSideEffect>
-            get() = _sideEffect.asSharedFlow()
+        val sideEffect: SharedFlow<OffboardingQuestReviewSideEffect> = _sideEffect.asSharedFlow()
 
         init {
             loadQuestRecordedDetail()
@@ -50,7 +45,7 @@ class OffboardingQuestReviewViewModel
                 _sideEffect.emit(
                     if (questType == QuestType.RECORDING) {
                         OffboardingQuestReviewSideEffect.NavigateToQuestRecordingEdit(
-                            questId = uiState.value.questId,
+                            questId = questIdArg,
                             isEditMode = true,
                             fromOffboarding = true,
                         )
@@ -61,7 +56,7 @@ class OffboardingQuestReviewViewModel
                             }
 
                         OffboardingQuestReviewSideEffect.NavigateToQuestBehaviorEdit(
-                            questId = uiState.value.questId,
+                            questId = questIdArg,
                             isEditMode = true,
                             fromOffboarding = true,
                             imageKey = imageKey,
@@ -83,11 +78,28 @@ class OffboardingQuestReviewViewModel
 
         private fun loadQuestRecordedDetail() {
             viewModelScope.launch {
+                _uiState.update {
+                    it.copy(
+                        isLoading = true,
+                    )
+                }
+
                 questRecordedDetailRepository
                     .observeQuestRecordedDetail(questIdArg)
-                    .collect { detail ->
+                    .catch {
+                        _uiState.update {
+                            it.copy(isLoading = false)
+                        }
+
+                        _sideEffect.emit(
+                            OffboardingQuestReviewSideEffect.ShowSnackBar(
+                                snackBarType = CustomSnackBarType.ALERT,
+                            ),
+                        )
+                    }.collect { detail ->
                         _uiState.update {
                             it.copy(
+                                isLoading = false,
                                 stepNumber = detail.stepNumber,
                                 questNumber = detail.questNumber,
                                 createdAt = detail.createdAt,
@@ -111,5 +123,13 @@ class OffboardingQuestReviewViewModel
         }
 
         fun onAiAnswerClicked() {
+            viewModelScope.launch {
+                _sideEffect.emit(
+                    OffboardingQuestReviewSideEffect.NavigateToQuestAiAnswer(
+                        questId = questIdArg,
+                        isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                    ),
+                )
+            }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
@@ -130,7 +130,6 @@ class OffboardingQuestReviewViewModel
                         questId = questIdArg,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
                         aiAnswerOrigin = AiAnswerOrigin.OFFBOARDING,
-                        questType = questTypeArg,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
@@ -42,7 +42,7 @@ class OffboardingQuestReviewViewModel
             get() = _sideEffect.asSharedFlow()
 
         init {
-            observeQuestRecordedDetail()
+            loadQuestRecordedDetail()
         }
 
         fun onEditClicked(questType: QuestType) {
@@ -81,7 +81,7 @@ class OffboardingQuestReviewViewModel
             }
         }
 
-        private fun observeQuestRecordedDetail() {
+        private fun loadQuestRecordedDetail() {
             viewModelScope.launch {
                 questRecordedDetailRepository
                     .observeQuestRecordedDetail(questIdArg)
@@ -103,9 +103,13 @@ class OffboardingQuestReviewViewModel
                                     } else {
                                         QuestType.ACTIVE
                                     },
+                                isExistedAiAnswer = detail.isExistedAiAnswer,
                             )
                         }
                     }
             }
+        }
+
+        fun onAiAnswerClicked() {
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/offboarding/offboardingquestreview/OffboardingQuestReviewViewModel.kt
@@ -129,7 +129,8 @@ class OffboardingQuestReviewViewModel
                     OffboardingQuestReviewSideEffect.NavigateToQuestAiAnswer(
                         questId = questIdArg,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
-                        aiAnswerOrigin = AiAnswerOrigin.Offboarding(questType = questTypeArg),
+                        aiAnswerOrigin = AiAnswerOrigin.OFFBOARDING,
+                        questType = questTypeArg,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/QuestViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/QuestViewModel.kt
@@ -8,7 +8,7 @@ import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.core.util.getFormattedDate
 import com.byeboo.app.domain.model.quest.CommonQuestAnswer
 import com.byeboo.app.domain.repository.auth.UserRepository
-import com.byeboo.app.domain.usecase.QuestUseCase
+import com.byeboo.app.domain.usecase.quest.QuestUseCase
 import com.byeboo.app.presentation.quest.model.CommonAnswerModel
 import com.byeboo.app.presentation.quest.model.Quest
 import com.byeboo.app.presentation.quest.model.QuestSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
@@ -28,6 +28,7 @@ import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.component.LoadingScreen
 import com.byeboo.app.core.designsystem.component.topbar.CloseTopbar
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.aianswer.type.QuestAiAnswerStatusType
@@ -37,6 +38,7 @@ import kotlinx.coroutines.flow.collectLatest
 fun QuestAiAnswerRoute(
     paddingValues: PaddingValues,
     navigateToQuest: () -> Unit,
+    navigateToOffboardingQuest: (QuestType) -> Unit,
     viewModel: QuestAiAnswerViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -45,7 +47,7 @@ fun QuestAiAnswerRoute(
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
                 is QuestAiAnswerSideEffect.NavigateToQuest -> navigateToQuest()
-                is QuestAiAnswerSideEffect.NavigateToOffboarding -> {}
+                is QuestAiAnswerSideEffect.NavigateToOffboardingQuest -> navigateToOffboardingQuest(effect.questType)
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
@@ -1,5 +1,6 @@
 package com.byeboo.app.presentation.quest.aianswer
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -46,6 +47,10 @@ fun QuestAiAnswerRoute(
                 is QuestAiAnswerSideEffect.NavigateToQuest -> navigateToQuest()
             }
         }
+    }
+
+    BackHandler {
+        navigateToQuest()
     }
 
     when (val state = uiState) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -29,13 +30,23 @@ import com.byeboo.app.core.state.UiState
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.aianswer.type.QuestAiAnswerStatusType
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun QuestAiAnswerRoute(
     paddingValues: PaddingValues,
+    navigateToQuest: () -> Unit,
     viewModel: QuestAiAnswerViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collectLatest { effect ->
+            when (effect) {
+                is QuestAiAnswerSideEffect.NavigateToQuest -> navigateToQuest()
+            }
+        }
+    }
 
     when (val state = uiState) {
         is UiState.Loading ->
@@ -114,8 +125,8 @@ private fun QuestAiAnswer(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 24.dp)
-                    .padding(top = 184.dp, bottom = 22.dp),
+                    .padding(horizontal = screenWidthDp(24.dp))
+                    .padding(top = screenHeightDp(184.dp), bottom = screenHeightDp(22.dp)),
             verticalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
@@ -25,9 +25,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.byeboo.app.R
+import com.byeboo.app.core.designsystem.component.LoadingScreen
 import com.byeboo.app.core.designsystem.component.topbar.CloseTopbar
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
-import com.byeboo.app.core.state.UiState
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.aianswer.type.QuestAiAnswerStatusType
@@ -45,37 +45,42 @@ fun QuestAiAnswerRoute(
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
                 is QuestAiAnswerSideEffect.NavigateToQuest -> navigateToQuest()
+                is QuestAiAnswerSideEffect.NavigateToOffboarding -> {}
             }
         }
     }
 
     BackHandler {
-        navigateToQuest()
+        viewModel.onCloseClicked()
     }
 
-    when (val state = uiState) {
-        is UiState.Loading ->
-            QuestAiAnswerStatusScreen(
-                paddingValues = paddingValues,
-                onCloseClick = viewModel::onCloseClicked,
-                statusType = QuestAiAnswerStatusType.LOADING,
-            )
+    when {
+        uiState.isLoading -> {
+            when (uiState.isExistedAiAnswer) {
+                true -> LoadingScreen()
 
-        is UiState.Failure ->
+                false ->
+                    QuestAiAnswerStatusScreen(
+                        paddingValues = paddingValues,
+                        onCloseClick = viewModel::onCloseClicked,
+                        statusType = QuestAiAnswerStatusType.LOADING,
+                    )
+            }
+        }
+
+        uiState.isFailure ->
             QuestAiAnswerStatusScreen(
                 paddingValues = paddingValues,
                 onCloseClick = viewModel::onCloseClicked,
                 statusType = QuestAiAnswerStatusType.FAIL,
             )
 
-        is UiState.Success ->
+        else ->
             QuestAiAnswerScreen(
-                uiState = state.data,
+                uiState = uiState,
                 paddingValues = paddingValues,
                 onCloseClick = viewModel::onCloseClicked,
             )
-
-        else -> Unit
     }
 }
 

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerScreen.kt
@@ -28,7 +28,6 @@ import com.byeboo.app.R
 import com.byeboo.app.core.designsystem.component.LoadingScreen
 import com.byeboo.app.core.designsystem.component.topbar.CloseTopbar
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
-import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.aianswer.type.QuestAiAnswerStatusType
@@ -38,7 +37,7 @@ import kotlinx.coroutines.flow.collectLatest
 fun QuestAiAnswerRoute(
     paddingValues: PaddingValues,
     navigateToQuest: () -> Unit,
-    navigateToOffboardingQuest: (QuestType) -> Unit,
+    navigateUp: () -> Unit,
     viewModel: QuestAiAnswerViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -47,7 +46,7 @@ fun QuestAiAnswerRoute(
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
                 is QuestAiAnswerSideEffect.NavigateToQuest -> navigateToQuest()
-                is QuestAiAnswerSideEffect.NavigateToOffboardingQuest -> navigateToOffboardingQuest(effect.questType)
+                is QuestAiAnswerSideEffect.NavigateUp -> navigateUp()
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
@@ -1,9 +1,14 @@
 package com.byeboo.app.presentation.quest.aianswer
 
 data class QuestAiAnswerState(
-    val questAiAnswer: String,
+    val questAiAnswer: String = "",
+    val isExistedAiAnswer: Boolean = false,
+    val isLoading: Boolean = false,
+    val isFailure: Boolean = false,
 )
 
 sealed interface QuestAiAnswerSideEffect {
     data object NavigateToQuest : QuestAiAnswerSideEffect
+
+    data object NavigateToOffboarding : QuestAiAnswerSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
@@ -1,5 +1,7 @@
 package com.byeboo.app.presentation.quest.aianswer
 
+import com.byeboo.app.core.designsystem.type.CustomSnackBarType
+
 data class QuestAiAnswerState(
     val questAiAnswer: String = "",
     val isExistedAiAnswer: Boolean = false,
@@ -11,4 +13,7 @@ sealed interface QuestAiAnswerSideEffect {
     data object NavigateToQuest : QuestAiAnswerSideEffect
 
     data object NavigateUp : QuestAiAnswerSideEffect
+    data class ShowSnackBar(
+        val snackBarType: CustomSnackBarType,
+    ) : QuestAiAnswerSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
@@ -3,3 +3,7 @@ package com.byeboo.app.presentation.quest.aianswer
 data class QuestAiAnswerState(
     val questAiAnswer: String,
 )
+
+sealed interface QuestAiAnswerSideEffect {
+    data object NavigateToQuest : QuestAiAnswerSideEffect
+}

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
@@ -1,7 +1,5 @@
 package com.byeboo.app.presentation.quest.aianswer
 
-import com.byeboo.app.core.designsystem.type.CustomSnackBarType
-
 data class QuestAiAnswerState(
     val questAiAnswer: String = "",
     val isExistedAiAnswer: Boolean = false,
@@ -13,8 +11,4 @@ sealed interface QuestAiAnswerSideEffect {
     data object NavigateToQuest : QuestAiAnswerSideEffect
 
     data object NavigateUp : QuestAiAnswerSideEffect
-
-    data class ShowSnackBar(
-        val snackBarType: CustomSnackBarType,
-    ) : QuestAiAnswerSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
@@ -1,5 +1,7 @@
 package com.byeboo.app.presentation.quest.aianswer
 
+import com.byeboo.app.core.model.quest.QuestType
+
 data class QuestAiAnswerState(
     val questAiAnswer: String = "",
     val isExistedAiAnswer: Boolean = false,
@@ -10,5 +12,7 @@ data class QuestAiAnswerState(
 sealed interface QuestAiAnswerSideEffect {
     data object NavigateToQuest : QuestAiAnswerSideEffect
 
-    data object NavigateToOffboarding : QuestAiAnswerSideEffect
+    data class NavigateToOffboardingQuest(
+        val questType: QuestType,
+    ) : QuestAiAnswerSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
@@ -1,7 +1,5 @@
 package com.byeboo.app.presentation.quest.aianswer
 
-import com.byeboo.app.core.model.quest.QuestType
-
 data class QuestAiAnswerState(
     val questAiAnswer: String = "",
     val isExistedAiAnswer: Boolean = false,
@@ -12,7 +10,5 @@ data class QuestAiAnswerState(
 sealed interface QuestAiAnswerSideEffect {
     data object NavigateToQuest : QuestAiAnswerSideEffect
 
-    data class NavigateToOffboardingQuest(
-        val questType: QuestType,
-    ) : QuestAiAnswerSideEffect
+    data object NavigateUp : QuestAiAnswerSideEffect
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerState.kt
@@ -13,6 +13,7 @@ sealed interface QuestAiAnswerSideEffect {
     data object NavigateToQuest : QuestAiAnswerSideEffect
 
     data object NavigateUp : QuestAiAnswerSideEffect
+
     data class ShowSnackBar(
         val snackBarType: CustomSnackBarType,
     ) : QuestAiAnswerSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.domain.usecase.quest.GetAiAnswerUseCase
 import com.byeboo.app.domain.usecase.quest.PostAiAnswerUseCase
 import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
@@ -31,7 +32,6 @@ class QuestAiAnswerViewModel
         private val questIdArg = args.questId
         private val isExistedAiAnswerArg = args.isExistedAiAnswer
         private val aiAnswerEntryPointArg = args.aiAnswerOrigin
-        private val questTypeArg = args.questType
 
         private val _uiState =
             MutableStateFlow(
@@ -78,6 +78,9 @@ class QuestAiAnswerViewModel
                                 isLoading = false,
                                 isFailure = true,
                             )
+                        }
+                        if (isExistedAiAnswerArg){
+                            _sideEffect.emit(QuestAiAnswerSideEffect.ShowSnackBar(snackBarType = CustomSnackBarType.ALERT))
                         }
                     }
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.byeboo.app.domain.usecase.quest.GetAiAnswerUseCase
 import com.byeboo.app.domain.usecase.quest.PostAiAnswerUseCase
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import com.byeboo.app.presentation.quest.navigation.QuestAiAnswer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -30,7 +30,7 @@ class QuestAiAnswerViewModel
         private val args = savedStateHandle.toRoute<QuestAiAnswer>()
         private val questIdArg = args.questId
         private val isExistedAiAnswerArg = args.isExistedAiAnswer
-        private val aiAnswerEntryPointArg = args.aiAnswerEntryPoint
+        private val aiAnswerEntryPointArg = args.aiAnswerOrigin
 
         private val _uiState =
             MutableStateFlow(
@@ -84,9 +84,12 @@ class QuestAiAnswerViewModel
 
         fun onCloseClicked() {
             viewModelScope.launch {
-                if (aiAnswerEntryPointArg == AiAnswerEntryPoint.QUEST) {
-                    _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
-                } else {
+                when (aiAnswerEntryPointArg) {
+                    is AiAnswerOrigin.Quest -> _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
+                    is AiAnswerOrigin.Offboarding ->
+                        _sideEffect.emit(
+                            QuestAiAnswerSideEffect.NavigateToOffboardingQuest(questType = aiAnswerEntryPointArg.questType),
+                        )
                 }
             }
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -1,29 +1,73 @@
 package com.byeboo.app.presentation.quest.aianswer
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.byeboo.app.core.state.UiState
+import com.byeboo.app.domain.usecase.quest.GetAiAnswerUseCase
+import com.byeboo.app.domain.usecase.quest.PostAiAnswerUseCase
+import com.byeboo.app.presentation.quest.navigation.QuestAiAnswer
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class QuestAiAnswerViewModel
     @Inject
-    constructor() : ViewModel() {
+    constructor(
+        private val getAiAnswerUseCase: GetAiAnswerUseCase,
+        private val postAiAnswerUseCase: PostAiAnswerUseCase,
+        savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        private val args = savedStateHandle.toRoute<QuestAiAnswer>()
+        private val questIdArg = args.questId
+        private val isExistedAiAnswerArg = args.isExistedAiAnswer
+
         private val _uiState = MutableStateFlow<UiState<QuestAiAnswerState>>(UiState.Loading)
         val uiState: StateFlow<UiState<QuestAiAnswerState>> = _uiState.asStateFlow()
+
+        private val _sideEffect = MutableSharedFlow<QuestAiAnswerSideEffect>()
+        val sideEffect: SharedFlow<QuestAiAnswerSideEffect> = _sideEffect.asSharedFlow()
 
         init {
             loadQuestAiAnswer()
         }
 
         private fun loadQuestAiAnswer() {
-            // TODO: 서버 연결
+            viewModelScope.launch {
+                _uiState.value = UiState.Loading
+
+                val result =
+                    if (isExistedAiAnswerArg) {
+                        getAiAnswerUseCase(questId = questIdArg)
+                    } else {
+                        postAiAnswerUseCase(questId = questIdArg)
+                    }
+
+                result
+                    .onSuccess { aiAnswer ->
+                        _uiState.value =
+                            UiState.Success(
+                                QuestAiAnswerState(
+                                    questAiAnswer = aiAnswer.aiAnswer,
+                                ),
+                            )
+                    }.onFailure {
+                        _uiState.value = UiState.Failure("AI 답변 생성에 실패했어요.")
+                    }
+            }
         }
 
         fun onCloseClicked() {
-            // TODO: 나의 여정 퀘스트 메인 화면으로 이동
+            viewModelScope.launch {
+                _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
+            }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -79,7 +79,7 @@ class QuestAiAnswerViewModel
                                 isFailure = true,
                             )
                         }
-                        if (isExistedAiAnswerArg){
+                        if (isExistedAiAnswerArg) {
                             _sideEffect.emit(QuestAiAnswerSideEffect.ShowSnackBar(snackBarType = CustomSnackBarType.ALERT))
                         }
                     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -89,12 +89,7 @@ class QuestAiAnswerViewModel
                     AiAnswerOrigin.QUEST -> _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
                     AiAnswerOrigin.OFFBOARDING ->
                         _sideEffect.emit(
-                            QuestAiAnswerSideEffect.NavigateToOffboardingQuest(
-                                questType =
-                                    requireNotNull(questTypeArg) {
-                                        "Offboarding entry requires questType"
-                                    },
-                            ),
+                            QuestAiAnswerSideEffect.NavigateUp,
                         )
                 }
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.byeboo.app.core.state.UiState
 import com.byeboo.app.domain.usecase.quest.GetAiAnswerUseCase
 import com.byeboo.app.domain.usecase.quest.PostAiAnswerUseCase
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import com.byeboo.app.presentation.quest.navigation.QuestAiAnswer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -29,9 +30,16 @@ class QuestAiAnswerViewModel
         private val args = savedStateHandle.toRoute<QuestAiAnswer>()
         private val questIdArg = args.questId
         private val isExistedAiAnswerArg = args.isExistedAiAnswer
+        private val aiAnswerEntryPointArg = args.aiAnswerEntryPoint
 
-        private val _uiState = MutableStateFlow<UiState<QuestAiAnswerState>>(UiState.Loading)
-        val uiState: StateFlow<UiState<QuestAiAnswerState>> = _uiState.asStateFlow()
+        private val _uiState =
+            MutableStateFlow(
+                QuestAiAnswerState(
+                    isExistedAiAnswer = isExistedAiAnswerArg,
+                    isLoading = true,
+                ),
+            )
+        val uiState: StateFlow<QuestAiAnswerState> = _uiState.asStateFlow()
 
         private val _sideEffect = MutableSharedFlow<QuestAiAnswerSideEffect>()
         val sideEffect: SharedFlow<QuestAiAnswerSideEffect> = _sideEffect.asSharedFlow()
@@ -42,7 +50,9 @@ class QuestAiAnswerViewModel
 
         private fun loadQuestAiAnswer() {
             viewModelScope.launch {
-                _uiState.value = UiState.Loading
+                _uiState.update {
+                    it.copy(isLoading = true)
+                }
 
                 val result =
                     if (isExistedAiAnswerArg) {
@@ -53,21 +63,31 @@ class QuestAiAnswerViewModel
 
                 result
                     .onSuccess { aiAnswer ->
-                        _uiState.value =
-                            UiState.Success(
-                                QuestAiAnswerState(
-                                    questAiAnswer = aiAnswer.aiAnswer,
-                                ),
+                        _uiState.update { state ->
+                            state.copy(
+                                questAiAnswer = aiAnswer.aiAnswer,
+                                isLoading = false,
+                                isFailure = false,
                             )
+                        }
                     }.onFailure {
-                        _uiState.value = UiState.Failure("AI 답변 생성에 실패했어요.")
+                        _uiState.update { state ->
+                            state.copy(
+                                questAiAnswer = "",
+                                isLoading = false,
+                                isFailure = true,
+                            )
+                        }
                     }
             }
         }
 
         fun onCloseClicked() {
             viewModelScope.launch {
-                _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
+                if (aiAnswerEntryPointArg == AiAnswerEntryPoint.QUEST) {
+                    _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
+                } else {
+                }
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.domain.usecase.quest.GetAiAnswerUseCase
 import com.byeboo.app.domain.usecase.quest.PostAiAnswerUseCase
 import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
@@ -78,9 +77,6 @@ class QuestAiAnswerViewModel
                                 isLoading = false,
                                 isFailure = true,
                             )
-                        }
-                        if (isExistedAiAnswerArg) {
-                            _sideEffect.emit(QuestAiAnswerSideEffect.ShowSnackBar(snackBarType = CustomSnackBarType.ALERT))
                         }
                     }
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/aianswer/QuestAiAnswerViewModel.kt
@@ -31,6 +31,7 @@ class QuestAiAnswerViewModel
         private val questIdArg = args.questId
         private val isExistedAiAnswerArg = args.isExistedAiAnswer
         private val aiAnswerEntryPointArg = args.aiAnswerOrigin
+        private val questTypeArg = args.questType
 
         private val _uiState =
             MutableStateFlow(
@@ -85,10 +86,15 @@ class QuestAiAnswerViewModel
         fun onCloseClicked() {
             viewModelScope.launch {
                 when (aiAnswerEntryPointArg) {
-                    is AiAnswerOrigin.Quest -> _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
-                    is AiAnswerOrigin.Offboarding ->
+                    AiAnswerOrigin.QUEST -> _sideEffect.emit(QuestAiAnswerSideEffect.NavigateToQuest)
+                    AiAnswerOrigin.OFFBOARDING ->
                         _sideEffect.emit(
-                            QuestAiAnswerSideEffect.NavigateToOffboardingQuest(questType = aiAnswerEntryPointArg.questType),
+                            QuestAiAnswerSideEffect.NavigateToOffboardingQuest(
+                                questType =
+                                    requireNotNull(questTypeArg) {
+                                        "Offboarding entry requires questType"
+                                    },
+                            ),
                         )
                 }
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
@@ -49,7 +49,6 @@ fun QuestBehaviorCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     paddingValues: PaddingValues,
-    modifier: Modifier = Modifier,
     viewModel: QuestBehaviorCompleteViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -87,7 +86,7 @@ fun QuestBehaviorCompleteRoute(
         paddingValues = paddingValues,
         onCloseClick = viewModel::onCloseClicked,
         imageUri = imageUri,
-        modifier = modifier,
+        onAiAnswerClick = viewModel::onAiAnswerClicked,
     )
 }
 
@@ -97,6 +96,7 @@ private fun QuestBehaviorCompleteScreen(
     paddingValues: PaddingValues,
     onCloseClick: () -> Unit,
     imageUri: Uri?,
+    onAiAnswerClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -191,11 +191,11 @@ private fun QuestBehaviorCompleteScreen(
                 Spacer(modifier = Modifier.height(screenHeightDp(20.dp)))
 
                 ByeBooButton(
-                    buttonText = "보리에게 답장 받기",
+                    buttonText = if (uiState.isExistedAiAnswer) "보리의 답장 보러가기" else "보리에게 답장받기",
                     buttonTextColor = ByeBooTheme.colors.white,
                     buttonStyle = ByeBooTheme.typography.body2,
                     buttonBackgroundColor = ByeBooTheme.colors.primary300,
-                    onClick = { /*Todo: ai 버튼 연결 */ },
+                    onClick = onAiAnswerClick,
                 )
             }
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
@@ -43,12 +43,13 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 
 @Composable
 fun QuestBehaviorCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     paddingValues: PaddingValues,
     viewModel: QuestBehaviorCompleteViewModel = hiltViewModel(),
 ) {
@@ -73,6 +74,7 @@ fun QuestBehaviorCompleteRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
+                        effect.aiAnswerEntryPoint,
                     )
                 is QuestBehaviorCompleteSideEffect.ShowInAppReview -> {
                     activity?.let { activity ->

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
@@ -43,13 +43,13 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 
 @Composable
 fun QuestBehaviorCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     paddingValues: PaddingValues,
     viewModel: QuestBehaviorCompleteViewModel = hiltViewModel(),
 ) {
@@ -74,7 +74,7 @@ fun QuestBehaviorCompleteRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
-                        effect.aiAnswerEntryPoint,
+                        effect.aiAnswerOrigin,
                     )
                 is QuestBehaviorCompleteSideEffect.ShowInAppReview -> {
                     activity?.let { activity ->

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
@@ -48,6 +48,7 @@ import com.byeboo.app.presentation.quest.component.text.QuestTitle
 fun QuestBehaviorCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     paddingValues: PaddingValues,
     viewModel: QuestBehaviorCompleteViewModel = hiltViewModel(),
 ) {
@@ -68,6 +69,11 @@ fun QuestBehaviorCompleteRoute(
             when (effect) {
                 is QuestBehaviorCompleteSideEffect.NavigateToQuest -> navigateToQuest()
                 is QuestBehaviorCompleteSideEffect.NavigateToOffboardingCompletedGuide -> navigateToOffboardingCompletedGuide()
+                is QuestBehaviorCompleteSideEffect.NavigateToQuestAiAnswer ->
+                    navigateToQuestAiAnswer(
+                        effect.questId,
+                        effect.isExistedAiAnswer,
+                    )
                 is QuestBehaviorCompleteSideEffect.ShowInAppReview -> {
                     activity?.let { activity ->
                         inAppReview(activity)

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.presentation.quest.behavior.complete
 import android.net.Uri
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 
 data class QuestBehaviorCompleteState(
     val questId: Long = 0,
@@ -29,6 +30,7 @@ sealed interface QuestBehaviorCompleteSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
+        val aiAnswerEntryPoint: AiAnswerEntryPoint,
     ) : QuestBehaviorCompleteSideEffect
 
     data object ShowInAppReview : QuestBehaviorCompleteSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
@@ -3,7 +3,7 @@ package com.byeboo.app.presentation.quest.behavior.complete
 import android.net.Uri
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 
 data class QuestBehaviorCompleteState(
     val questId: Long = 0,
@@ -30,7 +30,7 @@ sealed interface QuestBehaviorCompleteSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
-        val aiAnswerEntryPoint: AiAnswerEntryPoint,
+        val aiAnswerOrigin: AiAnswerOrigin,
     ) : QuestBehaviorCompleteSideEffect
 
     data object ShowInAppReview : QuestBehaviorCompleteSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
@@ -18,6 +18,7 @@ data class QuestBehaviorCompleteState(
     val selectedImageUri: Uri? = null,
     val emotionDescription: String = "",
     val selectedEmotion: EmotionChipType = EmotionChipType.EMOTION_NEUTRAL,
+    val isExistedAiAnswer: Boolean = false,
 )
 
 sealed interface QuestBehaviorCompleteSideEffect {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteState.kt
@@ -26,6 +26,11 @@ sealed interface QuestBehaviorCompleteSideEffect {
 
     data object NavigateToOffboardingCompletedGuide : QuestBehaviorCompleteSideEffect
 
+    data class NavigateToQuestAiAnswer(
+        val questId: Long,
+        val isExistedAiAnswer: Boolean,
+    ) : QuestBehaviorCompleteSideEffect
+
     data object ShowInAppReview : QuestBehaviorCompleteSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
@@ -46,8 +46,8 @@ class QuestBehaviorCompleteViewModel
 
         private fun loadQuestRecordedDetail() {
             viewModelScope.launch {
-                val result = questRecordedDetailRepository.getQuestRecordedDetail(questIdArg)
-                result
+                questRecordedDetailRepository
+                    .getQuestRecordedDetail(questIdArg)
                     .onSuccess { detail ->
                         _uiState.update {
                             it.copy(
@@ -59,6 +59,7 @@ class QuestBehaviorCompleteViewModel
                                 imageUrl = detail.imageUrl.orEmpty(),
                                 selectedEmotion = EmotionChipType.fromKorean(detail.questEmotionState),
                                 emotionDescription = detail.emotionDescription,
+                                isExistedAiAnswer = detail.isExistedAiAnswer,
                             )
                         }
                     }.onFailure {
@@ -95,5 +96,8 @@ class QuestBehaviorCompleteViewModel
                     }
                 }
             }
+        }
+
+        fun onAiAnswerClicked() {
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
@@ -10,6 +10,7 @@ import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.core.util.getFormattedDate
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -104,6 +105,7 @@ class QuestBehaviorCompleteViewModel
                     QuestBehaviorCompleteSideEffect.NavigateToQuestAiAnswer(
                         questId = uiState.value.questId,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                        aiAnswerEntryPoint = AiAnswerEntryPoint.QUEST,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
@@ -10,7 +10,7 @@ import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.core.util.getFormattedDate
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -105,7 +105,7 @@ class QuestBehaviorCompleteViewModel
                     QuestBehaviorCompleteSideEffect.NavigateToQuestAiAnswer(
                         questId = uiState.value.questId,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
-                        aiAnswerEntryPoint = AiAnswerEntryPoint.QUEST,
+                        aiAnswerOrigin = AiAnswerOrigin.QUEST,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteViewModel.kt
@@ -99,5 +99,13 @@ class QuestBehaviorCompleteViewModel
         }
 
         fun onAiAnswerClicked() {
+            viewModelScope.launch {
+                _sideEffect.emit(
+                    QuestBehaviorCompleteSideEffect.NavigateToQuestAiAnswer(
+                        questId = uiState.value.questId,
+                        isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                    ),
+                )
+            }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
@@ -44,6 +44,7 @@ fun NavGraphBuilder.questBehaviorGraph(
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     navigateUp: () -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     paddingValues: PaddingValues,
 ) {
     routeNavigation<QuestBehavior, QuestBehaviorWriting> {
@@ -62,6 +63,7 @@ fun NavGraphBuilder.questBehaviorGraph(
             QuestBehaviorCompleteRoute(
                 navigateToQuest = navigateToQuest,
                 navigateToOffboardingCompletedGuide = navigateToOffboardingCompletedGuide,
+                navigateToQuestAiAnswer = navigateToQuestAiAnswer,
                 paddingValues = paddingValues,
             )
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
@@ -11,7 +11,7 @@ import com.byeboo.app.presentation.quest.behavior.complete.QuestBehaviorComplete
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior.QuestBehaviorComplete
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior.QuestBehaviorWriting
 import com.byeboo.app.presentation.quest.behavior.writing.QuestBehaviorWritingRoute
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 
 fun NavController.navigateToQuestBehavior(
     questId: Long,
@@ -45,7 +45,7 @@ fun NavGraphBuilder.questBehaviorGraph(
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     navigateUp: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     paddingValues: PaddingValues,
 ) {
     routeNavigation<QuestBehavior, QuestBehaviorWriting> {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/navigation/QuestBehaviorNavigation.kt
@@ -11,6 +11,7 @@ import com.byeboo.app.presentation.quest.behavior.complete.QuestBehaviorComplete
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior.QuestBehaviorComplete
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior.QuestBehaviorWriting
 import com.byeboo.app.presentation.quest.behavior.writing.QuestBehaviorWritingRoute
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 
 fun NavController.navigateToQuestBehavior(
     questId: Long,
@@ -44,7 +45,7 @@ fun NavGraphBuilder.questBehaviorGraph(
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     navigateUp: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     paddingValues: PaddingValues,
 ) {
     routeNavigation<QuestBehavior, QuestBehaviorWriting> {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/writing/QuestBehaviorViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/writing/QuestBehaviorViewModel.kt
@@ -17,7 +17,7 @@ import com.byeboo.app.domain.model.quest.QuestWritingState
 import com.byeboo.app.domain.repository.quest.QuestBehaviorRepository
 import com.byeboo.app.domain.repository.quest.QuestDetailBehaviorRepository
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
-import com.byeboo.app.domain.usecase.UploadImageUseCase
+import com.byeboo.app.domain.usecase.quest.UploadImageUseCase
 import com.byeboo.app.presentation.quest.behavior.navigation.QuestBehavior
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerEntryPoint.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerEntryPoint.kt
@@ -1,0 +1,6 @@
+package com.byeboo.app.presentation.quest.navigation
+
+enum class AiAnswerEntryPoint {
+    QUEST,
+    OFFBOARDING,
+}

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerEntryPoint.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerEntryPoint.kt
@@ -1,6 +1,0 @@
-package com.byeboo.app.presentation.quest.navigation
-
-enum class AiAnswerEntryPoint {
-    QUEST,
-    OFFBOARDING,
-}

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerOrigin.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerOrigin.kt
@@ -1,15 +1,6 @@
 package com.byeboo.app.presentation.quest.navigation
 
-import com.byeboo.app.core.model.quest.QuestType
-import kotlinx.serialization.Serializable
-
-@Serializable
-sealed interface AiAnswerOrigin {
-    @Serializable
-    data object Quest : AiAnswerOrigin
-
-    @Serializable
-    data class Offboarding(
-        val questType: QuestType,
-    ) : AiAnswerOrigin
+enum class AiAnswerOrigin {
+    QUEST,
+    OFFBOARDING,
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerOrigin.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/AiAnswerOrigin.kt
@@ -1,0 +1,15 @@
+package com.byeboo.app.presentation.quest.navigation
+
+import com.byeboo.app.core.model.quest.QuestType
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface AiAnswerOrigin {
+    @Serializable
+    data object Quest : AiAnswerOrigin
+
+    @Serializable
+    data class Offboarding(
+        val questType: QuestType,
+    ) : AiAnswerOrigin
+}

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -66,10 +66,10 @@ fun NavController.navigateToQuestMyAnswerDetail(
 fun NavController.navigateToQuestAiAnswer(
     questId: Long,
     isExistedAiAnswer: Boolean,
-    aiAnswerEntryPoint: AiAnswerEntryPoint,
+    aiAnswerOrigin: AiAnswerOrigin,
     navOptions: NavOptions? = null,
 ) {
-    navigate(QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerEntryPoint = aiAnswerEntryPoint), navOptions)
+    navigate(QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerOrigin = aiAnswerOrigin), navOptions)
 }
 
 fun NavGraphBuilder.questGraph(
@@ -90,7 +90,8 @@ fun NavGraphBuilder.questGraph(
     navigateToQuestMyAnswers: () -> Unit,
     navigateToQuestMyAnswerDetail: (Long) -> Unit,
     navigateToQuestCommonComplete: (Long) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
+    navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
     paddingValues: PaddingValues,
 ) {
     routeNavigation<Quest, QuestStart> {
@@ -184,6 +185,7 @@ fun NavGraphBuilder.questGraph(
         composable<QuestAiAnswer> {
             QuestAiAnswerRoute(
                 navigateToQuest = navigateToQuest,
+                navigateToOffboardingQuest = navigateToOffboardingQuestCompleted,
                 paddingValues = paddingValues,
             )
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.core.util.routeNavigation
 import com.byeboo.app.presentation.quest.QuestRoute
+import com.byeboo.app.presentation.quest.aianswer.QuestAiAnswerRoute
 import com.byeboo.app.presentation.quest.behavior.navigation.questBehaviorGraph
 import com.byeboo.app.presentation.quest.common.navigation.questCommonGraph
 import com.byeboo.app.presentation.quest.record.navigation.questRecordGraph
@@ -62,6 +63,14 @@ fun NavController.navigateToQuestMyAnswerDetail(
     navigate(QuestMyAnswersDetail(answerId), navOptions)
 }
 
+fun NavController.navigateToQuestAiAnswer(
+    questId: Long,
+    isExistedAiAnswer: Boolean,
+    navOptions: NavOptions? = null,
+) {
+    navigate(QuestAiAnswer(questId, isExistedAiAnswer), navOptions)
+}
+
 fun NavGraphBuilder.questGraph(
     navigateUp: () -> Unit,
     navigateToQuest: () -> Unit,
@@ -80,6 +89,7 @@ fun NavGraphBuilder.questGraph(
     navigateToQuestMyAnswers: () -> Unit,
     navigateToQuestMyAnswerDetail: (Long) -> Unit,
     navigateToQuestCommonComplete: (Long) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     paddingValues: PaddingValues,
 ) {
     routeNavigation<Quest, QuestStart> {
@@ -116,6 +126,7 @@ fun NavGraphBuilder.questGraph(
                 navigateToQuest = navigateToQuest,
                 navigateToQuestRecordingEdit = navigateToQuestRecordingEdit,
                 navigateToQuestBehaviorEdit = navigateToQuestBehaviorEdit,
+                navigateToQuestAiAnswer = navigateToQuestAiAnswer,
                 paddingValues = paddingValues,
             )
         }
@@ -147,6 +158,7 @@ fun NavGraphBuilder.questGraph(
             navigateToQuestReview = navigateToQuestReview,
             navigateToOffboardingCompletedGuide = navigateToOffboardingCompletedGuide,
             navigateUp = navigateUp,
+            navigateToQuestAiAnswer = navigateToQuestAiAnswer,
             paddingValues = paddingValues,
         )
 
@@ -157,6 +169,7 @@ fun NavGraphBuilder.questGraph(
             navigateToQuestReview = navigateToQuestReview,
             navigateToOffboardingCompletedGuide = navigateToOffboardingCompletedGuide,
             navigateUp = navigateUp,
+            navigateToQuestAiAnswer = navigateToQuestAiAnswer,
             paddingValues = paddingValues,
         )
 
@@ -166,5 +179,12 @@ fun NavGraphBuilder.questGraph(
             navigateUp = navigateUp,
             paddingValues = paddingValues,
         )
+
+        composable<QuestAiAnswer> {
+            QuestAiAnswerRoute(
+                navigateToQuest = navigateToQuest,
+                paddingValues = paddingValues,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -66,9 +66,10 @@ fun NavController.navigateToQuestMyAnswerDetail(
 fun NavController.navigateToQuestAiAnswer(
     questId: Long,
     isExistedAiAnswer: Boolean,
+    aiAnswerEntryPoint: AiAnswerEntryPoint,
     navOptions: NavOptions? = null,
 ) {
-    navigate(QuestAiAnswer(questId, isExistedAiAnswer), navOptions)
+    navigate(QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerEntryPoint = aiAnswerEntryPoint), navOptions)
 }
 
 fun NavGraphBuilder.questGraph(
@@ -89,7 +90,7 @@ fun NavGraphBuilder.questGraph(
     navigateToQuestMyAnswers: () -> Unit,
     navigateToQuestMyAnswerDetail: (Long) -> Unit,
     navigateToQuestCommonComplete: (Long) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     paddingValues: PaddingValues,
 ) {
     routeNavigation<Quest, QuestStart> {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -95,7 +95,6 @@ fun NavGraphBuilder.questGraph(
     navigateToQuestCommonAnswer: (Long) -> Unit,
     navigateToQuestMyAnswers: () -> Unit,
     navigateToQuestMyAnswerDetail: (Long) -> Unit,
-    navigateToQuestCommonComplete: (Long) -> Unit,
     navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     navigateToQuestFromComplete: () -> Unit,
     paddingValues: PaddingValues,

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -70,7 +70,10 @@ fun NavController.navigateToQuestAiAnswer(
     questType: QuestType? = null,
     navOptions: NavOptions? = null,
 ) {
-    navigate(QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerOrigin = aiAnswerOrigin, questType = questType), navOptions)
+    navigate(
+        QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerOrigin = aiAnswerOrigin, questType = questType),
+        navOptions,
+    )
 }
 
 fun NavGraphBuilder.questGraph(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -67,11 +67,10 @@ fun NavController.navigateToQuestAiAnswer(
     questId: Long,
     isExistedAiAnswer: Boolean,
     aiAnswerOrigin: AiAnswerOrigin,
-    questType: QuestType? = null,
     navOptions: NavOptions? = null,
 ) {
     navigate(
-        QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerOrigin = aiAnswerOrigin, questType = questType),
+        QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerOrigin = aiAnswerOrigin),
         navOptions,
     )
 }
@@ -95,7 +94,6 @@ fun NavGraphBuilder.questGraph(
     navigateToQuestMyAnswerDetail: (Long) -> Unit,
     navigateToQuestCommonComplete: (Long) -> Unit,
     navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
-    navigateToOffboardingQuestCompleted: (QuestType) -> Unit,
     paddingValues: PaddingValues,
 ) {
     routeNavigation<Quest, QuestStart> {
@@ -189,7 +187,7 @@ fun NavGraphBuilder.questGraph(
         composable<QuestAiAnswer> {
             QuestAiAnswerRoute(
                 navigateToQuest = navigateToQuest,
-                navigateToOffboardingQuest = navigateToOffboardingQuestCompleted,
+                navigateUp = navigateUp,
                 paddingValues = paddingValues,
             )
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestNavigation.kt
@@ -67,9 +67,10 @@ fun NavController.navigateToQuestAiAnswer(
     questId: Long,
     isExistedAiAnswer: Boolean,
     aiAnswerOrigin: AiAnswerOrigin,
+    questType: QuestType? = null,
     navOptions: NavOptions? = null,
 ) {
-    navigate(QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerOrigin = aiAnswerOrigin), navOptions)
+    navigate(QuestAiAnswer(questId = questId, isExistedAiAnswer = isExistedAiAnswer, aiAnswerOrigin = aiAnswerOrigin, questType = questType), navOptions)
 }
 
 fun NavGraphBuilder.questGraph(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
@@ -43,4 +43,5 @@ data class QuestMyAnswersDetail(
 data class QuestAiAnswer(
     val questId: Long,
     val isExistedAiAnswer: Boolean,
+    val aiAnswerEntryPoint: AiAnswerEntryPoint,
 ) : Route

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
@@ -38,3 +38,9 @@ data object QuestMyAnswers : Route
 data class QuestMyAnswersDetail(
     val answerId: Long,
 ) : Route
+
+@Serializable
+data class QuestAiAnswer(
+    val questId: Long,
+    val isExistedAiAnswer: Boolean,
+) : Route

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
@@ -44,4 +44,5 @@ data class QuestAiAnswer(
     val questId: Long,
     val isExistedAiAnswer: Boolean,
     val aiAnswerOrigin: AiAnswerOrigin,
+    val questType: QuestType? = null,
 ) : Route

--- a/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/navigation/QuestRoute.kt
@@ -43,5 +43,5 @@ data class QuestMyAnswersDetail(
 data class QuestAiAnswer(
     val questId: Long,
     val isExistedAiAnswer: Boolean,
-    val aiAnswerEntryPoint: AiAnswerEntryPoint,
+    val aiAnswerOrigin: AiAnswerOrigin,
 ) : Route

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
@@ -31,12 +31,13 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 
 @Composable
 fun QuestRecordingCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     paddingValues: PaddingValues,
     viewModel: QuestRecordingCompleteViewModel = hiltViewModel(),
 ) {
@@ -54,6 +55,7 @@ fun QuestRecordingCompleteRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
+                        effect.aiAnswerEntryPoint,
                     )
                 is QuestRecordingCompleteSideEffect.ShowInAppReview -> {
                     activity?.let { activity ->

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
@@ -31,13 +31,13 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 
 @Composable
 fun QuestRecordingCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     paddingValues: PaddingValues,
     viewModel: QuestRecordingCompleteViewModel = hiltViewModel(),
 ) {
@@ -55,7 +55,7 @@ fun QuestRecordingCompleteRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
-                        effect.aiAnswerEntryPoint,
+                        effect.aiAnswerOrigin,
                     )
                 is QuestRecordingCompleteSideEffect.ShowInAppReview -> {
                     activity?.let { activity ->

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
@@ -36,6 +36,7 @@ import com.byeboo.app.presentation.quest.component.text.QuestTitle
 fun QuestRecordingCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     paddingValues: PaddingValues,
     viewModel: QuestRecordingCompleteViewModel = hiltViewModel(),
 ) {
@@ -49,6 +50,11 @@ fun QuestRecordingCompleteRoute(
             when (effect) {
                 is QuestRecordingCompleteSideEffect.NavigateToQuest -> navigateToQuest()
                 is QuestRecordingCompleteSideEffect.NavigateToOffboardingCompletedGuide -> navigateToOffboardingCompletedGuide()
+                is QuestRecordingCompleteSideEffect.NavigateToQuestAiAnswer ->
+                    navigateToQuestAiAnswer(
+                        effect.questId,
+                        effect.isExistedAiAnswer,
+                    )
                 is QuestRecordingCompleteSideEffect.ShowInAppReview -> {
                     activity?.let { activity ->
                         inAppReview(activity)

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteScreen.kt
@@ -37,7 +37,6 @@ fun QuestRecordingCompleteRoute(
     navigateToQuest: () -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
     paddingValues: PaddingValues,
-    modifier: Modifier = Modifier,
     viewModel: QuestRecordingCompleteViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -67,7 +66,7 @@ fun QuestRecordingCompleteRoute(
         uiState = uiState,
         paddingValues = paddingValues,
         onCloseClick = viewModel::onCloseClicked,
-        modifier = modifier,
+        onAiAnswerClick = viewModel::onAiAnswerClicked,
     )
 }
 
@@ -76,6 +75,7 @@ private fun QuestRecordingCompleteScreen(
     uiState: QuestRecordingCompleteState,
     paddingValues: PaddingValues,
     onCloseClick: () -> Unit,
+    onAiAnswerClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -122,11 +122,11 @@ private fun QuestRecordingCompleteScreen(
         }
 
         ByeBooButton(
-            buttonText = "보리에게 답장 받기",
+            buttonText = if (uiState.isExistedAiAnswer) "보리의 답장 보러가기" else "보리에게 답장받기",
             buttonTextColor = ByeBooTheme.colors.white,
             buttonStyle = ByeBooTheme.typography.body2,
             buttonBackgroundColor = ByeBooTheme.colors.primary300,
-            onClick = { /*Todo: ai 버튼 연결 */ },
+            onClick = onAiAnswerClick,
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
@@ -18,6 +18,7 @@ data class QuestRecordingCompleteState(
     val answer: String = "",
     val emotionDescription: String = "",
     val selectedEmotion: EmotionChipType = EmotionChipType.EMOTION_NEUTRAL,
+    val isExistedAiAnswer: Boolean = false,
 )
 
 sealed interface QuestRecordingCompleteSideEffect {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
@@ -26,6 +26,11 @@ sealed interface QuestRecordingCompleteSideEffect {
 
     data object NavigateToOffboardingCompletedGuide : QuestRecordingCompleteSideEffect
 
+    data class NavigateToQuestAiAnswer(
+        val questId: Long,
+        val isExistedAiAnswer: Boolean,
+    ) : QuestRecordingCompleteSideEffect
+
     data object ShowInAppReview : QuestRecordingCompleteSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
@@ -3,7 +3,7 @@ package com.byeboo.app.presentation.quest.record.complete
 import androidx.compose.runtime.Immutable
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import java.time.LocalDate
 
 @Immutable
@@ -30,7 +30,7 @@ sealed interface QuestRecordingCompleteSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
-        val aiAnswerEntryPoint: AiAnswerEntryPoint,
+        val aiAnswerOrigin: AiAnswerOrigin,
     ) : QuestRecordingCompleteSideEffect
 
     data object ShowInAppReview : QuestRecordingCompleteSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteState.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.presentation.quest.record.complete
 import androidx.compose.runtime.Immutable
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import java.time.LocalDate
 
 @Immutable
@@ -29,6 +30,7 @@ sealed interface QuestRecordingCompleteSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
+        val aiAnswerEntryPoint: AiAnswerEntryPoint,
     ) : QuestRecordingCompleteSideEffect
 
     data object ShowInAppReview : QuestRecordingCompleteSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
@@ -9,7 +9,7 @@ import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.core.util.getFormattedDate
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import com.byeboo.app.presentation.quest.record.navigation.QuestRecord
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -104,7 +104,7 @@ class QuestRecordingCompleteViewModel
                     QuestRecordingCompleteSideEffect.NavigateToQuestAiAnswer(
                         questId = uiState.value.questId,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
-                        aiAnswerEntryPoint = AiAnswerEntryPoint.QUEST,
+                        aiAnswerOrigin = AiAnswerOrigin.QUEST,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
@@ -47,8 +47,8 @@ class QuestRecordingCompleteViewModel
 
         private fun loadQuestRecordedDetail() {
             viewModelScope.launch {
-                val result = questRecordedDetailRepository.getQuestRecordedDetail(questIdArg)
-                result
+                questRecordedDetailRepository
+                    .getQuestRecordedDetail(questIdArg)
                     .onSuccess { detail ->
                         _uiState.update {
                             it.copy(
@@ -59,6 +59,7 @@ class QuestRecordingCompleteViewModel
                                 answer = detail.questAnswer,
                                 selectedEmotion = EmotionChipType.fromKorean(detail.questEmotionState),
                                 emotionDescription = detail.emotionDescription,
+                                isExistedAiAnswer = detail.isExistedAiAnswer,
                             )
                         }
                     }.onFailure {
@@ -94,5 +95,8 @@ class QuestRecordingCompleteViewModel
                     }
                 }
             }
+        }
+
+        fun onAiAnswerClicked() {
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
@@ -9,6 +9,7 @@ import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.core.util.getFormattedDate
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import com.byeboo.app.presentation.quest.record.navigation.QuestRecord
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -103,6 +104,7 @@ class QuestRecordingCompleteViewModel
                     QuestRecordingCompleteSideEffect.NavigateToQuestAiAnswer(
                         questId = uiState.value.questId,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                        aiAnswerEntryPoint = AiAnswerEntryPoint.QUEST,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/complete/QuestRecordingCompleteViewModel.kt
@@ -98,5 +98,13 @@ class QuestRecordingCompleteViewModel
         }
 
         fun onAiAnswerClicked() {
+            viewModelScope.launch {
+                _sideEffect.emit(
+                    QuestRecordingCompleteSideEffect.NavigateToQuestAiAnswer(
+                        questId = uiState.value.questId,
+                        isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                    ),
+                )
+            }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
@@ -41,6 +41,7 @@ fun NavGraphBuilder.questRecordGraph(
     navigateToQuestRecordingComplete: (Long) -> Unit,
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     navigateUp: () -> Unit,
     paddingValues: PaddingValues,
 ) {
@@ -60,6 +61,7 @@ fun NavGraphBuilder.questRecordGraph(
             QuestRecordingCompleteRoute(
                 navigateToQuest = navigateToQuest,
                 navigateToOffboardingCompletedGuide = navigateToOffboardingCompletedGuide,
+                navigateToQuestAiAnswer = navigateToQuestAiAnswer,
                 paddingValues = paddingValues,
             )
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
@@ -7,7 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.core.util.routeNavigation
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import com.byeboo.app.presentation.quest.record.complete.QuestRecordingCompleteRoute
 import com.byeboo.app.presentation.quest.record.navigation.QuestRecord.QuestRecordingComplete
 import com.byeboo.app.presentation.quest.record.navigation.QuestRecord.QuestRecordingWriting
@@ -42,7 +42,7 @@ fun NavGraphBuilder.questRecordGraph(
     navigateToQuestRecordingComplete: (Long) -> Unit,
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     navigateUp: () -> Unit,
     paddingValues: PaddingValues,
 ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/record/navigation/QuestRecordNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.core.util.routeNavigation
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import com.byeboo.app.presentation.quest.record.complete.QuestRecordingCompleteRoute
 import com.byeboo.app.presentation.quest.record.navigation.QuestRecord.QuestRecordingComplete
 import com.byeboo.app.presentation.quest.record.navigation.QuestRecord.QuestRecordingWriting
@@ -41,7 +42,7 @@ fun NavGraphBuilder.questRecordGraph(
     navigateToQuestRecordingComplete: (Long) -> Unit,
     navigateToQuestReview: (Long) -> Unit,
     navigateToOffboardingCompletedGuide: () -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     navigateUp: () -> Unit,
     paddingValues: PaddingValues,
 ) {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
@@ -41,7 +41,7 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import com.byeboo.app.presentation.quest.review.my.QuestReviewSideEffect
 import com.byeboo.app.presentation.quest.review.my.QuestReviewState
 import com.byeboo.app.presentation.quest.review.my.QuestReviewViewModel
@@ -54,7 +54,7 @@ fun QuestReviewRoute(
     navigateToQuest: () -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerOrigin) -> Unit,
     viewModel: QuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -81,7 +81,7 @@ fun QuestReviewRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
-                        effect.aiAnswerEntryPoint,
+                        effect.aiAnswerOrigin,
                     )
 
                 is QuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
@@ -41,6 +41,7 @@ import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
 import com.byeboo.app.presentation.quest.component.card.QuestEmotionDescriptionCard
 import com.byeboo.app.presentation.quest.component.text.QuestTitle
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import com.byeboo.app.presentation.quest.review.my.QuestReviewSideEffect
 import com.byeboo.app.presentation.quest.review.my.QuestReviewState
 import com.byeboo.app.presentation.quest.review.my.QuestReviewViewModel
@@ -53,7 +54,7 @@ fun QuestReviewRoute(
     navigateToQuest: () -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, String) -> Unit,
-    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean, AiAnswerEntryPoint) -> Unit,
     viewModel: QuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -80,6 +81,7 @@ fun QuestReviewRoute(
                     navigateToQuestAiAnswer(
                         effect.questId,
                         effect.isExistedAiAnswer,
+                        effect.aiAnswerEntryPoint,
                     )
 
                 is QuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.SubcomposeAsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
+import com.byeboo.app.core.designsystem.component.LoadingScreen
 import com.byeboo.app.core.designsystem.component.button.ByeBooButton
 import com.byeboo.app.core.designsystem.component.text.ContentText
 import com.byeboo.app.core.designsystem.event.LocalSnackBarTrigger
@@ -52,6 +53,7 @@ fun QuestReviewRoute(
     navigateToQuest: () -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, String) -> Unit,
+    navigateToQuestAiAnswer: (Long, Boolean) -> Unit,
     viewModel: QuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -66,12 +68,20 @@ fun QuestReviewRoute(
                         effect.questId,
                         true,
                     )
+
                 is QuestReviewSideEffect.NavigateToQuestBehaviorEdit ->
                     navigateToQuestBehaviorEdit(
                         effect.questId,
                         true,
                         effect.imageKey,
                     )
+
+                is QuestReviewSideEffect.NavigateToQuestAiAnswer ->
+                    navigateToQuestAiAnswer(
+                        effect.questId,
+                        effect.isExistedAiAnswer,
+                    )
+
                 is QuestReviewSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }
         }
@@ -81,13 +91,17 @@ fun QuestReviewRoute(
         navigateToQuest()
     }
 
-    QuestReviewScreen(
-        uiState = uiState,
-        paddingValues = paddingValues,
-        onBackClick = viewModel::onBackClicked,
-        onEditClick = { viewModel.onEditClicked(uiState.questType) },
-        onAiAnswerClick = viewModel::onAiAnswerClicked,
-    )
+    if (uiState.isLoading) {
+        LoadingScreen()
+    } else {
+        QuestReviewScreen(
+            uiState = uiState,
+            paddingValues = paddingValues,
+            onBackClick = viewModel::onBackClicked,
+            onEditClick = { viewModel.onEditClicked(uiState.questType) },
+            onAiAnswerClick = viewModel::onAiAnswerClicked,
+        )
+    }
 }
 
 @Composable
@@ -127,7 +141,7 @@ private fun QuestReviewScreen(
                     PaddingValues(
                         start = screenWidthDp(24.dp),
                         end = screenWidthDp(24.dp),
-                        bottom = screenHeightDp(28.dp),
+                        bottom = if (canScroll) screenHeightDp(28.dp) else screenHeightDp(90.dp),
                     ),
             ) {
                 item {
@@ -142,7 +156,9 @@ private fun QuestReviewScreen(
                 }
 
                 if (uiState.imageUrl.isNullOrBlank()) {
-                    item { ContentText(text = uiState.answer) }
+                    item {
+                        ContentText(text = uiState.answer)
+                    }
                 } else {
                     item {
                         Column(
@@ -167,10 +183,13 @@ private fun QuestReviewScreen(
                                     Box(
                                         modifier = Modifier.fillMaxSize(),
                                         contentAlignment = Alignment.Center,
-                                    ) { CircularProgressIndicator() }
+                                    ) {
+                                        CircularProgressIndicator()
+                                    }
                                 },
                             )
                         }
+
                         if (uiState.answer.isNotBlank()) {
                             Spacer(modifier = Modifier.height(screenHeightDp(20.dp)))
                             ContentText(uiState.answer)
@@ -200,6 +219,21 @@ private fun QuestReviewScreen(
                         )
                     }
                 }
+            }
+
+            if (!canScroll) {
+                ByeBooButton(
+                    buttonText = if (uiState.isExistedAiAnswer) "보리의 답장 보러가기" else "보리에게 답장받기",
+                    buttonTextColor = ByeBooTheme.colors.white,
+                    buttonStyle = ByeBooTheme.typography.body2,
+                    buttonBackgroundColor = ByeBooTheme.colors.primary300,
+                    onClick = onAiAnswerClick,
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(horizontal = screenWidthDp(24.dp))
+                            .padding(bottom = screenHeightDp(10.dp)),
+                )
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewScreen.kt
@@ -52,7 +52,6 @@ fun QuestReviewRoute(
     navigateToQuest: () -> Unit,
     navigateToQuestRecordingEdit: (Long, Boolean) -> Unit,
     navigateToQuestBehaviorEdit: (Long, Boolean, String) -> Unit,
-    modifier: Modifier = Modifier,
     viewModel: QuestReviewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -87,7 +86,7 @@ fun QuestReviewRoute(
         paddingValues = paddingValues,
         onBackClick = viewModel::onBackClicked,
         onEditClick = { viewModel.onEditClicked(uiState.questType) },
-        modifier = modifier,
+        onAiAnswerClick = viewModel::onAiAnswerClicked,
     )
 }
 
@@ -97,6 +96,7 @@ private fun QuestReviewScreen(
     paddingValues: PaddingValues,
     onBackClick: () -> Unit,
     onEditClick: () -> Unit,
+    onAiAnswerClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -192,11 +192,11 @@ private fun QuestReviewScreen(
                         Spacer(modifier = Modifier.height(screenHeightDp(20.dp)))
 
                         ByeBooButton(
-                            buttonText = "보리에게 답장 받기",
+                            buttonText = if (uiState.isExistedAiAnswer) "보리의 답장 보러가기" else "보리에게 답장받기",
                             buttonTextColor = ByeBooTheme.colors.white,
                             buttonStyle = ByeBooTheme.typography.body2,
                             buttonBackgroundColor = ByeBooTheme.colors.primary300,
-                            onClick = { /*Todo: ai 버튼 연결 */ },
+                            onClick = onAiAnswerClick,
                         )
                     }
                 }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
@@ -18,6 +18,7 @@ data class QuestReviewState(
     val emotionDescription: String = "",
     val selectedEmotion: EmotionChipType = EmotionChipType.EMOTION_NEUTRAL,
     val questType: QuestType = QuestType.RECORDING,
+    val isExistedAiAnswer: Boolean = false,
 )
 
 sealed interface QuestReviewSideEffect {

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
@@ -6,7 +6,7 @@ import com.byeboo.app.core.model.quest.QuestType
 import java.time.LocalDate
 
 data class QuestReviewState(
-    val questId: Long = 0,
+    val isLoading: Boolean = true,
     val stepNumber: Long = 0,
     val questNumber: Long = 0,
     val createdAt: String = LocalDate.now().toString(),
@@ -33,6 +33,11 @@ sealed interface QuestReviewSideEffect {
         val questId: Long,
         val isEditMode: Boolean,
         val imageKey: String,
+    ) : QuestReviewSideEffect
+
+    data class NavigateToQuestAiAnswer(
+        val questId: Long,
+        val isExistedAiAnswer: Boolean,
     ) : QuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
@@ -3,7 +3,7 @@ package com.byeboo.app.presentation.quest.review.my
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import java.time.LocalDate
 
 data class QuestReviewState(
@@ -39,7 +39,7 @@ sealed interface QuestReviewSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
-        val aiAnswerEntryPoint: AiAnswerEntryPoint,
+        val aiAnswerOrigin: AiAnswerOrigin,
     ) : QuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewState.kt
@@ -3,6 +3,7 @@ package com.byeboo.app.presentation.quest.review.my
 import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import java.time.LocalDate
 
 data class QuestReviewState(
@@ -38,6 +39,7 @@ sealed interface QuestReviewSideEffect {
     data class NavigateToQuestAiAnswer(
         val questId: Long,
         val isExistedAiAnswer: Boolean,
+        val aiAnswerEntryPoint: AiAnswerEntryPoint,
     ) : QuestReviewSideEffect
 
     data class ShowSnackBar(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
@@ -80,30 +80,27 @@ class QuestReviewViewModel
 
         private fun loadQuestRecordedDetail() {
             viewModelScope.launch {
-                val result =
-                    questRecordedDetailRepository.getQuestRecordedDetail(
+                questRecordedDetailRepository
+                    .getQuestRecordedDetail(
                         uiState.value.questId,
-                    )
-                result
-                    .onSuccess { detail ->
+                    ).onSuccess { detail ->
                         _uiState.update {
-                            val newState =
-                                it.copy(
-                                    stepNumber = detail.stepNumber,
-                                    questNumber = detail.questNumber,
-                                    createdAt = detail.createdAt,
-                                    question = detail.question,
-                                    answer = detail.questAnswer,
-                                    imageKey = detail.imageKey.orEmpty(),
-                                    imageUrl = detail.imageUrl.orEmpty(),
-                                    selectedEmotion =
-                                        EmotionChipType.fromKorean(
-                                            detail.questEmotionState,
-                                        ),
-                                    emotionDescription = detail.emotionDescription,
-                                    questType = if (detail.imageUrl == null) QuestType.RECORDING else QuestType.ACTIVE,
-                                )
-                            newState
+                            it.copy(
+                                stepNumber = detail.stepNumber,
+                                questNumber = detail.questNumber,
+                                createdAt = detail.createdAt,
+                                question = detail.question,
+                                answer = detail.questAnswer,
+                                imageKey = detail.imageKey.orEmpty(),
+                                imageUrl = detail.imageUrl.orEmpty(),
+                                selectedEmotion =
+                                    EmotionChipType.fromKorean(
+                                        detail.questEmotionState,
+                                    ),
+                                emotionDescription = detail.emotionDescription,
+                                questType = if (detail.imageUrl == null) QuestType.RECORDING else QuestType.ACTIVE,
+                                isExistedAiAnswer = detail.isExistedAiAnswer,
+                            )
                         }
                     }.onFailure {
                         _sideEffect.emit(
@@ -113,5 +110,8 @@ class QuestReviewViewModel
                         )
                     }
             }
+        }
+
+        fun onAiAnswerClicked() {
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
@@ -27,20 +27,13 @@ class QuestReviewViewModel
         private val questRecordedDetailRepository: QuestRecordedDetailRepository,
         savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
-        val questIdArg: Long = savedStateHandle.toRoute<QuestReview>().questId
+        private val questIdArg: Long = savedStateHandle.toRoute<QuestReview>().questId
 
-        private val _uiState =
-            MutableStateFlow(
-                QuestReviewState(
-                    questId = questIdArg,
-                ),
-            )
-        val uiState: StateFlow<QuestReviewState>
-            get() = _uiState.asStateFlow()
+        private val _uiState = MutableStateFlow(QuestReviewState())
+        val uiState: StateFlow<QuestReviewState> = _uiState.asStateFlow()
 
         private val _sideEffect = MutableSharedFlow<QuestReviewSideEffect>()
-        val sideEffect: SharedFlow<QuestReviewSideEffect>
-            get() = _sideEffect.asSharedFlow()
+        val sideEffect: SharedFlow<QuestReviewSideEffect> = _sideEffect.asSharedFlow()
 
         init {
             loadQuestRecordedDetail()
@@ -51,7 +44,7 @@ class QuestReviewViewModel
                 _sideEffect.emit(
                     if (questType == QuestType.RECORDING) {
                         QuestReviewSideEffect.NavigateToQuestRecordingEdit(
-                            questId = uiState.value.questId,
+                            questId = questIdArg,
                             isEditMode = true,
                         )
                     } else {
@@ -61,7 +54,7 @@ class QuestReviewViewModel
                             }
 
                         QuestReviewSideEffect.NavigateToQuestBehaviorEdit(
-                            questId = uiState.value.questId,
+                            questId = questIdArg,
                             isEditMode = true,
                             imageKey = imageKey,
                         )
@@ -80,12 +73,19 @@ class QuestReviewViewModel
 
         private fun loadQuestRecordedDetail() {
             viewModelScope.launch {
+                _uiState.update {
+                    it.copy(
+                        isLoading = true,
+                    )
+                }
+
                 questRecordedDetailRepository
                     .getQuestRecordedDetail(
-                        uiState.value.questId,
+                        questId = questIdArg,
                     ).onSuccess { detail ->
                         _uiState.update {
                             it.copy(
+                                isLoading = false,
                                 stepNumber = detail.stepNumber,
                                 questNumber = detail.questNumber,
                                 createdAt = detail.createdAt,
@@ -103,6 +103,10 @@ class QuestReviewViewModel
                             )
                         }
                     }.onFailure {
+                        _uiState.update {
+                            it.copy(isLoading = false)
+                        }
+
                         _sideEffect.emit(
                             QuestReviewSideEffect.ShowSnackBar(
                                 snackBarType = CustomSnackBarType.ALERT,
@@ -113,5 +117,13 @@ class QuestReviewViewModel
         }
 
         fun onAiAnswerClicked() {
+            viewModelScope.launch {
+                _sideEffect.emit(
+                    QuestReviewSideEffect.NavigateToQuestAiAnswer(
+                        questId = questIdArg,
+                        isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                    ),
+                )
+            }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
@@ -8,6 +8,7 @@ import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
+import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
 import com.byeboo.app.presentation.quest.navigation.QuestReview
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -122,6 +123,7 @@ class QuestReviewViewModel
                     QuestReviewSideEffect.NavigateToQuestAiAnswer(
                         questId = questIdArg,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
+                        aiAnswerEntryPoint = AiAnswerEntryPoint.QUEST,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/my/QuestReviewViewModel.kt
@@ -8,7 +8,7 @@ import com.byeboo.app.core.designsystem.type.CustomSnackBarType
 import com.byeboo.app.core.designsystem.type.EmotionChipType
 import com.byeboo.app.core.model.quest.QuestType
 import com.byeboo.app.domain.repository.quest.QuestRecordedDetailRepository
-import com.byeboo.app.presentation.quest.navigation.AiAnswerEntryPoint
+import com.byeboo.app.presentation.quest.navigation.AiAnswerOrigin
 import com.byeboo.app.presentation.quest.navigation.QuestReview
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -123,7 +123,7 @@ class QuestReviewViewModel
                     QuestReviewSideEffect.NavigateToQuestAiAnswer(
                         questId = questIdArg,
                         isExistedAiAnswer = uiState.value.isExistedAiAnswer,
-                        aiAnswerEntryPoint = AiAnswerEntryPoint.QUEST,
+                        aiAnswerOrigin = AiAnswerOrigin.QUEST,
                     ),
                 )
             }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/util/QuestMapper.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/util/QuestMapper.kt
@@ -3,7 +3,7 @@ package com.byeboo.app.presentation.quest.util
 import androidx.annotation.DrawableRes
 import com.byeboo.app.R
 import com.byeboo.app.core.model.quest.QuestType
-import com.byeboo.app.domain.model.quest.QuestData
+import com.byeboo.app.domain.model.quest.QuestDataModel
 import com.byeboo.app.presentation.quest.model.Quest
 import com.byeboo.app.presentation.quest.model.QuestGroup
 import com.byeboo.app.presentation.quest.model.QuestOutput
@@ -20,7 +20,7 @@ import javax.inject.Inject
 class QuestUiModelMapper
     @Inject
     constructor() {
-        fun mapToPresentationModel(data: QuestData): QuestOutput {
+        fun mapToPresentationModel(data: QuestDataModel): QuestOutput {
             val inProgress = data.inProgressQuest
             val currentStep = inProgress.currentStep
             val serverNow = inProgress.currentTime


### PR DESCRIPTION
## Related issue 🛠
- closed #277 

## Work Description 📝
- ai 답장 api 연동
- ai 답장 생성
- ai 답장 조회
- 네비 연결

## Screenshot 📸

## Uncompleted Tasks 😅
- N/A

## PR Point 📌
이번 작업 맡은 화면에선 UiState를 이용하는 것 대신 state에서 isLoading 값을 이용해서 화면 구성했습니다!

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 퀘스트 AI 답변 조회/생성 기능 추가(화면, 네비게이션, 원천 구분)
  * AI 답변용 모델·DTO·서비스·데이터소스·리포지토리·유즈케이스 추가

* **UI 변경**
  * 완료·리뷰·오프보딩 화면에 AI 답변 버튼 및 상태(로딩/존재/실패) 노출
  * 스크롤에 따른 하단 버튼 레이아웃 및 버튼 텍스트 조건부 표시 추가

* **개선**
  * 네비게이션·상태·사이드이펙트 흐름 및 로딩 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->