### PR TITLE
[qa/#302] Sprint 3 2차 QA

### DIFF
--- a/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
@@ -1,6 +1,5 @@
 package com.byeboo.app.core.network
 
-import com.byeboo.app.core.network.AuthInterceptor.Companion.BEARER
 import com.byeboo.app.domain.repository.auth.AuthRepository
 import com.byeboo.app.domain.repository.auth.TokenRepository
 import kotlinx.coroutines.Dispatchers
@@ -15,87 +14,87 @@ import okhttp3.Route
 import javax.inject.Inject
 
 class TokenAuthenticator
-@Inject
-constructor(
-    private val tokenRepository: TokenRepository,
-    private val authRepository: AuthRepository,
-) : Authenticator {
+    @Inject
+    constructor(
+        private val tokenRepository: TokenRepository,
+        private val authRepository: AuthRepository,
+    ) : Authenticator {
+        private val mutex = Mutex()
 
-    private val mutex = Mutex()
+        override fun authenticate(
+            route: Route?,
+            response: Response,
+        ): Request? {
+            if (responseCount(response) >= 2) return null
 
-    override fun authenticate(
-        route: Route?,
-        response: Response,
-    ): Request? {
-        if (responseCount(response) >= 2) return null
+            return runBlocking(Dispatchers.IO) {
+                try {
+                    mutex.withLock {
+                        val currentAccessToken =
+                            tokenRepository.getAccessToken().firstOrNull().orEmpty()
+                        val requestAccessToken =
+                            response.request
+                                .header(AUTHORIZATION)
+                                ?.substringAfter(BEARER)
+                                ?.trim()
+                                .orEmpty()
 
-        return runBlocking(Dispatchers.IO) {
-            try {
-                mutex.withLock {
-                    val currentAccessToken =
-                        tokenRepository.getAccessToken().firstOrNull().orEmpty()
-                    val requestAccessToken =
-                        response.request.header(AUTHORIZATION)?.substringAfter(BEARER)?.trim()
-                            .orEmpty()
+                        if (currentAccessToken != requestAccessToken) {
+                            return@runBlocking response.request
+                                .newBuilder()
+                                .removeHeader(AUTHORIZATION)
+                                .addHeader(AUTHORIZATION, "$BEARER $currentAccessToken")
+                                .build()
+                        }
 
-                    if (currentAccessToken != requestAccessToken) {
+                        val refreshToken = tokenRepository.getRefreshToken().firstOrNull().orEmpty()
+
+                        if (refreshToken.isEmpty()) {
+                            tokenRepository.clearTokens()
+                            tokenRepository.setLoginSplash(true)
+                            return@runBlocking null
+                        }
+
+                        val result = authRepository.reissueAccessToken(refreshToken)
+                        val newAuthenticatedToken = result.getOrNull()
+
+                        if (newAuthenticatedToken == null) {
+                            tokenRepository.clearTokens()
+                            tokenRepository.setLoginSplash(true)
+                            return@runBlocking null
+                        }
+
+                        tokenRepository.saveTokens(newAuthenticatedToken)
+
                         return@runBlocking response.request
                             .newBuilder()
                             .removeHeader(AUTHORIZATION)
-                            .addHeader(AUTHORIZATION, "$BEARER $currentAccessToken")
-                            .build()
+                            .addHeader(
+                                AUTHORIZATION,
+                                "$BEARER ${newAuthenticatedToken.accessToken}",
+                            ).build()
                     }
-
-                    val refreshToken = tokenRepository.getRefreshToken().firstOrNull().orEmpty()
-
-                    if (refreshToken.isEmpty()) {
-                        tokenRepository.clearTokens()
-                        tokenRepository.setLoginSplash(true)
-                        return@runBlocking null
-                    }
-
-                    val result = authRepository.reissueAccessToken(refreshToken)
-                    val newAuthenticatedToken = result.getOrNull()
-
-                    if (newAuthenticatedToken == null) {
-                        tokenRepository.clearTokens()
-                        tokenRepository.setLoginSplash(true)
-                        return@runBlocking null
-                    }
-
-                    tokenRepository.saveTokens(newAuthenticatedToken)
-
-                    return@runBlocking response.request
-                        .newBuilder()
-                        .removeHeader(AUTHORIZATION)
-                        .addHeader(
-                            AUTHORIZATION,
-                            "$BEARER ${newAuthenticatedToken.accessToken}"
-                        )
-                        .build()
+                } catch (e: Exception) {
+                    tokenRepository.clearTokens()
+                    tokenRepository.setLoginSplash(true)
+                    return@runBlocking null
                 }
-            } catch (e: Exception) {
-                tokenRepository.clearTokens()
-                tokenRepository.setLoginSplash(true)
-                return@runBlocking null
             }
         }
 
-    }
+        private fun responseCount(response: Response): Int {
+            var response: Response? = response
+            var count = 1
 
-    private fun responseCount(response: Response): Int {
-        var response: Response? = response
-        var count = 1
-
-        while (response?.priorResponse != null) {
-            count++
-            response = response.priorResponse
+            while (response?.priorResponse != null) {
+                count++
+                response = response.priorResponse
+            }
+            return count
         }
-        return count
-    }
 
-    companion object {
-        const val AUTHORIZATION = "Authorization"
-        const val BEARER = "Bearer"
+        companion object {
+            const val AUTHORIZATION = "Authorization"
+            const val BEARER = "Bearer"
+        }
     }
-}

--- a/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
@@ -1,9 +1,13 @@
 package com.byeboo.app.core.network
 
+import com.byeboo.app.core.network.AuthInterceptor.Companion.BEARER
 import com.byeboo.app.domain.repository.auth.AuthRepository
 import com.byeboo.app.domain.repository.auth.TokenRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
@@ -11,58 +15,87 @@ import okhttp3.Route
 import javax.inject.Inject
 
 class TokenAuthenticator
-    @Inject
-    constructor(
-        private val tokenRepository: TokenRepository,
-        private val authRepository: AuthRepository,
-    ) : Authenticator {
-        override fun authenticate(
-            route: Route?,
-            response: Response,
-        ): Request? =
-            runBlocking {
-                if (responseCount(response) >= 2) return@runBlocking null
+@Inject
+constructor(
+    private val tokenRepository: TokenRepository,
+    private val authRepository: AuthRepository,
+) : Authenticator {
 
-                val refreshToken = tokenRepository.getRefreshToken().firstOrNull()
+    private val mutex = Mutex()
 
-                if (refreshToken.isNullOrEmpty()) {
-                    tokenRepository.clearTokens()
-                    tokenRepository.setLoginSplash(true)
-                    return@runBlocking null
+    override fun authenticate(
+        route: Route?,
+        response: Response,
+    ): Request? {
+        if (responseCount(response) >= 2) return null
+
+        return runBlocking(Dispatchers.IO) {
+            try {
+                mutex.withLock {
+                    val currentAccessToken =
+                        tokenRepository.getAccessToken().firstOrNull().orEmpty()
+                    val requestAccessToken =
+                        response.request.header(AUTHORIZATION)?.substringAfter(BEARER)?.trim()
+                            .orEmpty()
+
+                    if (currentAccessToken != requestAccessToken) {
+                        return@runBlocking response.request
+                            .newBuilder()
+                            .removeHeader(AUTHORIZATION)
+                            .addHeader(AUTHORIZATION, "$BEARER $currentAccessToken")
+                            .build()
+                    }
+
+                    val refreshToken = tokenRepository.getRefreshToken().firstOrNull().orEmpty()
+
+                    if (refreshToken.isEmpty()) {
+                        tokenRepository.clearTokens()
+                        tokenRepository.setLoginSplash(true)
+                        return@runBlocking null
+                    }
+
+                    val result = authRepository.reissueAccessToken(refreshToken)
+                    val newAuthenticatedToken = result.getOrNull()
+
+                    if (newAuthenticatedToken == null) {
+                        tokenRepository.clearTokens()
+                        tokenRepository.setLoginSplash(true)
+                        return@runBlocking null
+                    }
+
+                    tokenRepository.saveTokens(newAuthenticatedToken)
+
+                    return@runBlocking response.request
+                        .newBuilder()
+                        .removeHeader(AUTHORIZATION)
+                        .addHeader(
+                            AUTHORIZATION,
+                            "$BEARER ${newAuthenticatedToken.accessToken}"
+                        )
+                        .build()
                 }
-
-                val result = authRepository.reissueAccessToken(refreshToken)
-
-                val newAuthenticatedToken = result.getOrNull()
-
-                if (newAuthenticatedToken == null) {
-                    tokenRepository.clearTokens()
-                    tokenRepository.setLoginSplash(true)
-                    return@runBlocking null
-                }
-
-                tokenRepository.saveTokens(newAuthenticatedToken)
-
-                response.request
-                    .newBuilder()
-                    .removeHeader(AUTHORIZATION)
-                    .addHeader(AUTHORIZATION, "$BEARER ${newAuthenticatedToken.accessToken}")
-                    .build()
+            } catch (e: Exception) {
+                tokenRepository.clearTokens()
+                tokenRepository.setLoginSplash(true)
+                return@runBlocking null
             }
-
-        private fun responseCount(response: Response): Int {
-            var response: Response? = response
-            var count = 1
-
-            while (response?.priorResponse != null) {
-                count++
-                response = response.priorResponse
-            }
-            return count
         }
 
-        companion object {
-            const val AUTHORIZATION = "Authorization"
-            const val BEARER = "Bearer"
-        }
     }
+
+    private fun responseCount(response: Response): Int {
+        var response: Response? = response
+        var count = 1
+
+        while (response?.priorResponse != null) {
+            count++
+            response = response.priorResponse
+        }
+        return count
+    }
+
+    companion object {
+        const val AUTHORIZATION = "Authorization"
+        const val BEARER = "Bearer"
+    }
+}

--- a/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
@@ -23,7 +23,13 @@ class TokenAuthenticator
             runBlocking {
                 if (responseCount(response) >= 2) return@runBlocking null
 
-                val refreshToken = tokenRepository.getRefreshToken().firstOrNull() ?: return@runBlocking null
+                val refreshToken = tokenRepository.getRefreshToken().firstOrNull()
+
+                if (refreshToken.isNullOrEmpty()) {
+                    tokenRepository.clearTokens()
+                    tokenRepository.setLoginSplash(true)
+                    return@runBlocking null
+                }
 
                 val result = authRepository.reissueAccessToken(refreshToken)
 

--- a/app/src/main/java/com/byeboo/app/core/util/TimeUtil.kt
+++ b/app/src/main/java/com/byeboo/app/core/util/TimeUtil.kt
@@ -7,7 +7,7 @@ import java.time.ZoneId
 object TimeUtil {
     private val KST_ZONE = ZoneId.of("Asia/Seoul")
 
-    val QUEST_START_DATE: LocalDate = LocalDate.of(2026, 3, 3)
+    val QUEST_START_DATE: LocalDate = LocalDate.of(2026, 3, 6)
 
     fun getNowKst(): LocalDate = LocalDate.now(KST_ZONE)
 

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
@@ -4,43 +4,53 @@ import com.byeboo.app.core.model.auth.TokenEntity
 import com.byeboo.app.data.datasource.local.TokenDataSource
 import com.byeboo.app.domain.repository.auth.TokenRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
 class TokenRepositoryImpl
-    @Inject
-    constructor(
-        private val tokenDataSource: TokenDataSource,
-    ) : TokenRepository {
-        @Volatile private var cachedAccessToken: String = ""
+@Inject
+constructor(
+    private val tokenDataSource: TokenDataSource,
+) : TokenRepository {
+    @Volatile
+    private var cachedAccessToken: String = ""
 
-        override fun getAccessToken(): Flow<String> = tokenDataSource.getAccessToken()
+    private val _tokenExpiredEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-        override fun getRefreshToken(): Flow<String> = tokenDataSource.getRefreshToken()
+    override val tokenExpiredEvent: Flow<Unit> = _tokenExpiredEvent.asSharedFlow()
 
-        override suspend fun saveTokens(tokens: TokenEntity) {
-            tokenDataSource.updateTokens(tokens.accessToken, tokens.refreshToken)
-            updateCachedAccessToken(tokens.accessToken)
-        }
+    override fun getAccessToken(): Flow<String> = tokenDataSource.getAccessToken()
 
-        override suspend fun clearTokens() {
-            tokenDataSource.clearTokens()
-            updateCachedAccessToken("")
-        }
+    override fun getRefreshToken(): Flow<String> = tokenDataSource.getRefreshToken()
 
-        override suspend fun initCachedAccessToken() {
-            cachedAccessToken = tokenDataSource.getAccessToken().firstOrNull().orEmpty()
-        }
-
-        override fun getCachedAccessToken(): String = cachedAccessToken
-
-        override fun updateCachedAccessToken(token: String) {
-            cachedAccessToken = token
-        }
-
-        override suspend fun setLoginSplash(show: Boolean) {
-            tokenDataSource.setLoginSplash(show)
-        }
-
-        override suspend fun restartSplash(): Boolean = tokenDataSource.restartSplash()
+    override suspend fun saveTokens(tokens: TokenEntity) {
+        tokenDataSource.updateTokens(tokens.accessToken, tokens.refreshToken)
+        updateCachedAccessToken(tokens.accessToken)
     }
+
+    override suspend fun clearTokens() {
+        tokenDataSource.clearTokens()
+        updateCachedAccessToken("")
+    }
+
+    override suspend fun initCachedAccessToken() {
+        cachedAccessToken = tokenDataSource.getAccessToken().firstOrNull().orEmpty()
+    }
+
+    override fun getCachedAccessToken(): String = cachedAccessToken
+
+    override fun updateCachedAccessToken(token: String) {
+        cachedAccessToken = token
+    }
+
+    override suspend fun setLoginSplash(show: Boolean) {
+        tokenDataSource.setLoginSplash(show)
+        if (show) {
+            _tokenExpiredEvent.tryEmit(Unit)
+        }
+    }
+
+    override suspend fun restartSplash(): Boolean = tokenDataSource.restartSplash()
+}

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
@@ -10,47 +10,47 @@ import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
 class TokenRepositoryImpl
-@Inject
-constructor(
-    private val tokenDataSource: TokenDataSource,
-) : TokenRepository {
-    @Volatile
-    private var cachedAccessToken: String = ""
+    @Inject
+    constructor(
+        private val tokenDataSource: TokenDataSource,
+    ) : TokenRepository {
+        @Volatile
+        private var cachedAccessToken: String = ""
 
-    private val _tokenExpiredEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        private val _tokenExpiredEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-    override val tokenExpiredEvent: Flow<Unit> = _tokenExpiredEvent.asSharedFlow()
+        override val tokenExpiredEvent: Flow<Unit> = _tokenExpiredEvent.asSharedFlow()
 
-    override fun getAccessToken(): Flow<String> = tokenDataSource.getAccessToken()
+        override fun getAccessToken(): Flow<String> = tokenDataSource.getAccessToken()
 
-    override fun getRefreshToken(): Flow<String> = tokenDataSource.getRefreshToken()
+        override fun getRefreshToken(): Flow<String> = tokenDataSource.getRefreshToken()
 
-    override suspend fun saveTokens(tokens: TokenEntity) {
-        tokenDataSource.updateTokens(tokens.accessToken, tokens.refreshToken)
-        updateCachedAccessToken(tokens.accessToken)
-    }
-
-    override suspend fun clearTokens() {
-        tokenDataSource.clearTokens()
-        updateCachedAccessToken("")
-    }
-
-    override suspend fun initCachedAccessToken() {
-        cachedAccessToken = tokenDataSource.getAccessToken().firstOrNull().orEmpty()
-    }
-
-    override fun getCachedAccessToken(): String = cachedAccessToken
-
-    override fun updateCachedAccessToken(token: String) {
-        cachedAccessToken = token
-    }
-
-    override suspend fun setLoginSplash(show: Boolean) {
-        tokenDataSource.setLoginSplash(show)
-        if (show) {
-            _tokenExpiredEvent.tryEmit(Unit)
+        override suspend fun saveTokens(tokens: TokenEntity) {
+            tokenDataSource.updateTokens(tokens.accessToken, tokens.refreshToken)
+            updateCachedAccessToken(tokens.accessToken)
         }
-    }
 
-    override suspend fun restartSplash(): Boolean = tokenDataSource.restartSplash()
-}
+        override suspend fun clearTokens() {
+            tokenDataSource.clearTokens()
+            updateCachedAccessToken("")
+        }
+
+        override suspend fun initCachedAccessToken() {
+            cachedAccessToken = tokenDataSource.getAccessToken().firstOrNull().orEmpty()
+        }
+
+        override fun getCachedAccessToken(): String = cachedAccessToken
+
+        override fun updateCachedAccessToken(token: String) {
+            cachedAccessToken = token
+        }
+
+        override suspend fun setLoginSplash(show: Boolean) {
+            tokenDataSource.setLoginSplash(show)
+            if (show) {
+                _tokenExpiredEvent.tryEmit(Unit)
+            }
+        }
+
+        override suspend fun restartSplash(): Boolean = tokenDataSource.restartSplash()
+    }

--- a/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface TokenRepository {
     val tokenExpiredEvent: Flow<Unit>
+
     fun getAccessToken(): Flow<String>
 
     fun getRefreshToken(): Flow<String>

--- a/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
@@ -4,6 +4,7 @@ import com.byeboo.app.core.model.auth.TokenEntity
 import kotlinx.coroutines.flow.Flow
 
 interface TokenRepository {
+    val tokenExpiredEvent: Flow<Unit>
     fun getAccessToken(): Flow<String>
 
     fun getRefreshToken(): Flow<String>

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
@@ -42,9 +42,10 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.tokenExpiredEvent.collect {
-                    val intent = Intent(this@MainActivity, MainActivity::class.java).apply {
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    }
+                    val intent =
+                        Intent(this@MainActivity, MainActivity::class.java).apply {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                        }
                     startActivity(intent)
                     finish()
                 }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainActivity.kt
@@ -8,8 +8,12 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -25,9 +29,25 @@ class MainActivity : ComponentActivity() {
 
         viewModel.handleIntent(intent)
 
+        observeTokenExpiredEvent()
+
         setContent {
             ByeBooTheme {
                 MainScreen()
+            }
+        }
+    }
+
+    private fun observeTokenExpiredEvent() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.tokenExpiredEvent.collect {
+                    val intent = Intent(this@MainActivity, MainActivity::class.java).apply {
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    }
+                    startActivity(intent)
+                    finish()
+                }
             }
         }
     }

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
@@ -36,6 +36,7 @@ class MainViewModel
         val questHomeNavigation: StateFlow<Boolean> = _questHomeNavigation.asStateFlow()
 
         val tokenExpiredEvent: Flow<Unit> = tokenRepository.tokenExpiredEvent
+
         fun trackJourneyStart() {
             viewModelScope.launch {
                 val journey = questStateRepository.getUserJourney() ?: "추적 실패"

--- a/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/main/MainViewModel.kt
@@ -5,10 +5,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.domain.model.JourneyStatusType
+import com.byeboo.app.domain.repository.auth.TokenRepository
 import com.byeboo.app.domain.repository.quest.QuestStateRepository
 import com.byeboo.app.fcm.ByebooNotificationHandler.Companion.DESTINATION
 import com.byeboo.app.fcm.ByebooNotificationHandler.Companion.QUEST_HOME
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +24,7 @@ class MainViewModel
     @Inject
     constructor(
         private val questStateRepository: QuestStateRepository,
+        private val tokenRepository: TokenRepository,
         private val mixpanelUtil: MixpanelUtil,
     ) : ViewModel() {
         val journeyStatus: StateFlow<JourneyStatusType> =
@@ -32,6 +35,7 @@ class MainViewModel
         private val _questHomeNavigation = MutableStateFlow<Boolean>(false)
         val questHomeNavigation: StateFlow<Boolean> = _questHomeNavigation.asStateFlow()
 
+        val tokenExpiredEvent: Flow<Unit> = tokenRepository.tokenExpiredEvent
         fun trackJourneyStart() {
             viewModelScope.launch {
                 val journey = questStateRepository.getUserJourney() ?: "추적 실패"

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
@@ -125,7 +125,6 @@ private fun QuestBehaviorCompleteScreen(
             modifier
                 .fillMaxSize()
                 .background(ByeBooTheme.colors.background)
-                .padding(horizontal = screenWidthDp(24.dp))
                 .padding(
                     top = paddingValues.calculateTopPadding() + screenHeightDp(43.dp),
                     bottom = paddingValues.calculateBottomPadding(),
@@ -133,6 +132,7 @@ private fun QuestBehaviorCompleteScreen(
     ) {
         CloseTopbar(
             onCloseClick = onCloseClick,
+            modifier = Modifier.padding(horizontal = screenWidthDp(24.dp))
         )
 
         LazyColumn(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/behavior/complete/QuestBehaviorCompleteScreen.kt
@@ -132,7 +132,7 @@ private fun QuestBehaviorCompleteScreen(
     ) {
         CloseTopbar(
             onCloseClick = onCloseClick,
-            modifier = Modifier.padding(horizontal = screenWidthDp(24.dp))
+            modifier = Modifier.padding(horizontal = screenWidthDp(24.dp)),
         )
 
         LazyColumn(

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/common/personal/detail/MyDetailAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/common/personal/detail/MyDetailAnswerViewModel.kt
@@ -68,7 +68,7 @@ class MyDetailAnswerViewModel
                                 state.answer.copy(
                                     answerId = cached.answerId,
                                     question = cached.question,
-                                    writtenAt = cached.writtenAt,
+                                    writtenAt = DateUtil.formatToDotDate(cached.writtenAt),
                                     content = cached.content,
                                 ),
                         )


### PR DESCRIPTION
## Related issue 🛠
- closed #302

## Work Description 📝
- 공통퀘스트 작성일 형식 수정
- 자동로그인 401 에러 해결

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- N/A

## PR Point 📌
- mutex를 활용해서 최초의 401 요청만 Reissue API 를 호출하고, 
나머지 요청들은 대기하다가 갱신된 새 토큰을 주입 받고 서버 통신을 재수행하도록 로직 구현

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토큰 만료 이벤트 공개 및 감지 추가로 세션 관리/자동 재로그인 동작 개선

* **Bug Fixes**
  * 토큰 갱신 재시도·동시성 처리 개선으로 인증 안정성 향상
  * 답변 작성 날짜 표시 포맷 일관성 수정
  * 토큰 재발급 실패 시 안전하게 로그인 화면 복구

* **Style**
  * 화면 패딩 조정 및 퀘스트 시작 날짜 범위 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->