### PR TITLE
[feat/#305] 플레이스토어 강제 업데이트 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,6 +136,8 @@ dependencies {
     implementation(platform(libs.google.firebase.bom))
     implementation(libs.google.firebase.crashlytics)
     implementation(libs.google.firebase.messaging)
+    implementation(libs.google.firebase.config)
+    implementation(libs.google.play.app.update)
 
     // Network
     implementation(platform(libs.okhttp.bom))
@@ -172,6 +174,7 @@ dependencies {
     // DataStore
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
+
 }
 
 ktlint {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -174,7 +174,6 @@ dependencies {
     // DataStore
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
-
 }
 
 ktlint {

--- a/app/src/main/java/com/byeboo/app/core/util/ContextExt.kt
+++ b/app/src/main/java/com/byeboo/app/core/util/ContextExt.kt
@@ -19,15 +19,16 @@ fun Context.hasNotificationPermission(): Boolean =
     }
 
 fun Context.navigateToPlayStore() {
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=$packageName")).apply {
-        setPackage("com.android.vending")
-    }
+    val intent =
+        Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=$packageName")).apply {
+            setPackage("com.android.vending")
+        }
 
     runCatching {
         startActivity(intent)
     }.onFailure {
         startActivity(
-            Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=$packageName"))
+            Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=$packageName")),
         )
     }
 }

--- a/app/src/main/java/com/byeboo/app/core/util/ContextExt.kt
+++ b/app/src/main/java/com/byeboo/app/core/util/ContextExt.kt
@@ -2,7 +2,9 @@ package com.byeboo.app.core.util
 
 import android.Manifest.permission.POST_NOTIFICATIONS
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import androidx.core.content.ContextCompat
 
@@ -15,3 +17,17 @@ fun Context.hasNotificationPermission(): Boolean =
     } else {
         true
     }
+
+fun Context.navigateToPlayStore() {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=$packageName")).apply {
+        setPackage("com.android.vending")
+    }
+
+    runCatching {
+        startActivity(intent)
+    }.onFailure {
+        startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=$packageName"))
+        )
+    }
+}

--- a/app/src/main/java/com/byeboo/app/data/di/ConfigModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/ConfigModule.kt
@@ -11,10 +11,7 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class ConfigModule {
-
     @Binds
     @Singleton
-    abstract fun bindConfigRepository(
-        configRepositoryImpl: ConfigRepositoryImpl
-    ): ConfigRepository
+    abstract fun bindConfigRepository(configRepositoryImpl: ConfigRepositoryImpl): ConfigRepository
 }

--- a/app/src/main/java/com/byeboo/app/data/di/ConfigModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/ConfigModule.kt
@@ -1,0 +1,20 @@
+package com.byeboo.app.data.di
+
+import com.byeboo.app.data.repositoryimpl.config.ConfigRepositoryImpl
+import com.byeboo.app.domain.repository.config.ConfigRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ConfigModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindConfigRepository(
+        configRepositoryImpl: ConfigRepositoryImpl
+    ): ConfigRepository
+}

--- a/app/src/main/java/com/byeboo/app/data/di/FirebaseModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/FirebaseModule.kt
@@ -1,0 +1,26 @@
+package com.byeboo.app.data.di
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseModule {
+
+    @Provides
+    @Singleton
+    fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig {
+        val remoteConfig = FirebaseRemoteConfig.getInstance()
+        remoteConfig.setConfigSettingsAsync(
+            FirebaseRemoteConfigSettings.Builder()
+                .setMinimumFetchIntervalInSeconds(3600)
+                .build()
+        )
+        return remoteConfig
+    }
+}

--- a/app/src/main/java/com/byeboo/app/data/di/FirebaseModule.kt
+++ b/app/src/main/java/com/byeboo/app/data/di/FirebaseModule.kt
@@ -11,15 +11,15 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object FirebaseModule {
-
     @Provides
     @Singleton
     fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig {
         val remoteConfig = FirebaseRemoteConfig.getInstance()
         remoteConfig.setConfigSettingsAsync(
-            FirebaseRemoteConfigSettings.Builder()
+            FirebaseRemoteConfigSettings
+                .Builder()
                 .setMinimumFetchIntervalInSeconds(3600)
-                .build()
+                .build(),
         )
         return remoteConfig
     }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/config/ConfigRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/config/ConfigRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.byeboo.app.data.repositoryimpl.config
+
+import com.byeboo.app.BuildConfig
+import com.byeboo.app.domain.repository.config.ConfigRepository
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class ConfigRepositoryImpl @Inject constructor(
+    private val remoteConfig: FirebaseRemoteConfig
+) : ConfigRepository {
+
+    override suspend fun getMinVersionCode(): Int {
+        return runCatching {
+            remoteConfig.fetchAndActivate().await()
+            remoteConfig.getLong("min_version_code").toInt()
+        }.getOrDefault(0)
+    }
+
+    override fun isUpdateRequired(minVersion: Int): Boolean {
+        return BuildConfig.VERSION_CODE < minVersion
+    }
+}

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/config/ConfigRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/config/ConfigRepositoryImpl.kt
@@ -6,18 +6,16 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
-class ConfigRepositoryImpl @Inject constructor(
-    private val remoteConfig: FirebaseRemoteConfig
-) : ConfigRepository {
+class ConfigRepositoryImpl
+    @Inject
+    constructor(
+        private val remoteConfig: FirebaseRemoteConfig,
+    ) : ConfigRepository {
+        override suspend fun getMinVersionCode(): Int =
+            runCatching {
+                remoteConfig.fetchAndActivate().await()
+                remoteConfig.getLong("min_version_code").toInt()
+            }.getOrDefault(0)
 
-    override suspend fun getMinVersionCode(): Int {
-        return runCatching {
-            remoteConfig.fetchAndActivate().await()
-            remoteConfig.getLong("min_version_code").toInt()
-        }.getOrDefault(0)
+        override fun isUpdateRequired(minVersion: Int): Boolean = BuildConfig.VERSION_CODE < minVersion
     }
-
-    override fun isUpdateRequired(minVersion: Int): Boolean {
-        return BuildConfig.VERSION_CODE < minVersion
-    }
-}

--- a/app/src/main/java/com/byeboo/app/domain/repository/config/ConfigRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/config/ConfigRepository.kt
@@ -2,5 +2,6 @@ package com.byeboo.app.domain.repository.config
 
 interface ConfigRepository {
     suspend fun getMinVersionCode(): Int
+
     fun isUpdateRequired(minVersion: Int): Boolean
 }

--- a/app/src/main/java/com/byeboo/app/domain/repository/config/ConfigRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/config/ConfigRepository.kt
@@ -1,0 +1,6 @@
+package com.byeboo.app.domain.repository.config
+
+interface ConfigRepository {
+    suspend fun getMinVersionCode(): Int
+    fun isUpdateRequired(minVersion: Int): Boolean
+}

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashScreen.kt
@@ -47,6 +47,7 @@ import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
 import com.byeboo.app.core.util.noRippleClickable
 import com.byeboo.app.core.util.screenHeightDp
 import com.byeboo.app.core.util.screenWidthDp
+import com.byeboo.app.presentation.splash.component.ForceUpdateDialog
 import com.kakao.sdk.user.UserApiClient
 
 @Composable
@@ -62,6 +63,8 @@ fun SplashRoute(
     val showSnackBar = LocalSnackBarTrigger.current
     var showLoginButton by remember { mutableStateOf(false) }
 
+    var isUpdateRequired by remember { mutableStateOf(false) }
+
     val permissionLauncher =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.RequestPermission(),
@@ -73,6 +76,9 @@ fun SplashRoute(
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { effect ->
             when (effect) {
+                is SplashStateSideEffect.ShowForceUpdateDialog -> {
+                    isUpdateRequired = true
+                }
                 is SplashStateSideEffect.ShowLoginButton -> {
                     showLoginButton = true
                 }
@@ -105,6 +111,10 @@ fun SplashRoute(
                 is SplashStateSideEffect.ShowSnackBar -> showSnackBar(effect.snackBarType)
             }
         }
+    }
+
+    if (isUpdateRequired) {
+        ForceUpdateDialog()
     }
 
     SplashScreen(

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashState.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashState.kt
@@ -17,6 +17,8 @@ sealed interface SplashStateSideEffect {
 
     data object RequestNotificationPermission : SplashStateSideEffect
 
+    data object ShowForceUpdateDialog : SplashStateSideEffect
+
     data class ShowSnackBar(
         val snackBarType: CustomSnackBarType,
     ) : SplashStateSideEffect

--- a/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/SplashViewModel.kt
@@ -8,6 +8,7 @@ import com.byeboo.app.core.util.MixpanelUtil
 import com.byeboo.app.domain.model.notification.FcmTokenModel
 import com.byeboo.app.domain.repository.auth.TokenRepository
 import com.byeboo.app.domain.repository.auth.UserRepository
+import com.byeboo.app.domain.repository.config.ConfigRepository
 import com.byeboo.app.domain.repository.fcm.FcmTokenRepository
 import com.byeboo.app.domain.usecase.LoginUseCase
 import com.byeboo.app.domain.usecase.ReissueAccessTokenUseCase
@@ -30,6 +31,7 @@ import javax.inject.Inject
 class SplashViewModel
     @Inject
     constructor(
+        private val configRepository: ConfigRepository,
         private val tokenRepository: TokenRepository,
         private val userRepository: UserRepository,
         private val fcmTokenRepository: FcmTokenRepository,
@@ -45,6 +47,12 @@ class SplashViewModel
 
         init {
             viewModelScope.launch {
+                val minVersion = configRepository.getMinVersionCode()
+                if (configRepository.isUpdateRequired(minVersion)) {
+                    _sideEffect.emit(SplashStateSideEffect.ShowForceUpdateDialog)
+                    return@launch
+                }
+
                 tokenRepository.initCachedAccessToken()
 
                 if (tokenRepository.restartSplash()) {

--- a/app/src/main/java/com/byeboo/app/presentation/splash/component/ForceUpdateDialog.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/component/ForceUpdateDialog.kt
@@ -1,0 +1,72 @@
+package com.byeboo.app.presentation.splash.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.byeboo.app.core.designsystem.component.button.ByeBooButton
+import com.byeboo.app.core.designsystem.ui.theme.ByeBooTheme
+import com.byeboo.app.core.util.navigateToPlayStore
+import com.byeboo.app.core.util.screenHeightDp
+import com.byeboo.app.core.util.screenWidthDp
+
+@Composable
+fun ForceUpdateDialog() {
+    val context = LocalContext.current
+
+    Dialog(
+        onDismissRequest = { },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(ByeBooTheme.colors.background)
+                .padding(vertical = screenHeightDp(24.dp),horizontal = screenWidthDp(24.dp)),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "새로운 업데이트가 있어요",
+                style = ByeBooTheme.typography.sub3,
+                color = ByeBooTheme.colors.gray50,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+
+            Text(
+                text = "더 나은 바이부를 만나보세요",
+                style = ByeBooTheme.typography.body3,
+                color = ByeBooTheme.colors.gray400,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
+
+            ByeBooButton(
+                onClick = context::navigateToPlayStore,
+                buttonText = "업데이트 하러 가기",
+                buttonStyle = ByeBooTheme.typography.body2,
+                buttonTextColor = ByeBooTheme.colors.white,
+                buttonBackgroundColor = ByeBooTheme.colors.primary300
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/byeboo/app/presentation/splash/component/ForceUpdateDialog.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/splash/component/ForceUpdateDialog.kt
@@ -29,24 +29,26 @@ fun ForceUpdateDialog() {
 
     Dialog(
         onDismissRequest = { },
-        properties = DialogProperties(
-            dismissOnBackPress = false,
-            dismissOnClickOutside = false
-        )
+        properties =
+            DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
+            ),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
-                .background(ByeBooTheme.colors.background)
-                .padding(vertical = screenHeightDp(24.dp),horizontal = screenWidthDp(24.dp)),
-            horizontalAlignment = Alignment.CenterHorizontally
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(ByeBooTheme.colors.background)
+                    .padding(vertical = screenHeightDp(24.dp), horizontal = screenWidthDp(24.dp)),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = "새로운 업데이트가 있어요",
                 style = ByeBooTheme.typography.sub3,
                 color = ByeBooTheme.colors.gray50,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
             )
 
             Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
@@ -55,7 +57,7 @@ fun ForceUpdateDialog() {
                 text = "더 나은 바이부를 만나보세요",
                 style = ByeBooTheme.typography.body3,
                 color = ByeBooTheme.colors.gray400,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
             )
 
             Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
@@ -65,7 +67,7 @@ fun ForceUpdateDialog() {
                 buttonText = "업데이트 하러 가기",
                 buttonStyle = ByeBooTheme.typography.body2,
                 buttonTextColor = ByeBooTheme.colors.white,
-                buttonBackgroundColor = ByeBooTheme.colors.primary300
+                buttonBackgroundColor = ByeBooTheme.colors.primary300,
             )
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@
 compileSdk = "36"
 minSdk = "28"
 targetSdk = "35"
-versionCode = "3"
-versionName = "1.0.2"
+versionCode = "10"
+versionName = "2.0.1"
 
 # Kotlin
 agp = "8.9.2"
@@ -72,6 +72,9 @@ datastore = "1.1.7"
 
 # in-app
 googlePlayInappReview = "2.0.2"
+
+# Google Play Update
+googlePlayAppUpdate = "2.1.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -147,6 +150,12 @@ google-play-inapp-review-ktx = { group = "com.google.android.play", name = "revi
 # DataStore
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-datastore-core = { group = "androidx.datastore", name = "datastore-core", version.ref = "datastore" }
+
+# Firebase Remote Config
+google-firebase-config = { group = "com.google.firebase", name = "firebase-config" }
+
+# Google Play App Update
+google-play-app-update = { group = "com.google.android.play", name = "app-update-ktx", version.ref = "googlePlayAppUpdate" }
 
 [bundles]
 androidx = [


### PR DESCRIPTION
## Related issue 🛠
- closed #305 

## Work Description 📝
- 낮은 버전에서 플레이스토어 강제 업데이트를 구현했습니다.

## Screenshot 📸

<img src="https://github.com/user-attachments/assets/9189a784-41ab-4cb7-b508-693ba11d9373" width="360"/>

## Uncompleted Tasks 😅


## PR Point 📌
`Firebase Remote Config`를 활용해 앱 버전 관리 시스템을 구축했습니다. 

서버의 최소 요구 버전과 기기 버전을 비교하여, 구버전 사용자에게는 뒤로가기가 차단된 강제 업데이트 다이얼로그를 노출합니다. 

1시간 단위의 캐시 최적화를 구현했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 업데이트 알림: 앱 실행 시 필수 업데이트 여부를 확인하고, 업데이트가 필요한 경우 알림 대화창을 표시합니다. 사용자는 대화창의 버튼을 통해 Play Store에서 바로 업데이트할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->