### PR TITLE
[fix/#307] 로그아웃, 탈퇴 시에 발생하는 앱 재실행 수정

### DIFF
--- a/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/byeboo/app/core/network/TokenAuthenticator.kt
@@ -51,7 +51,7 @@ class TokenAuthenticator
 
                         if (refreshToken.isEmpty()) {
                             tokenRepository.clearTokens()
-                            tokenRepository.setLoginSplash(true)
+                            tokenRepository.setLoginSplash(show = true, isTokenExpired = true)
                             return@runBlocking null
                         }
 
@@ -60,7 +60,7 @@ class TokenAuthenticator
 
                         if (newAuthenticatedToken == null) {
                             tokenRepository.clearTokens()
-                            tokenRepository.setLoginSplash(true)
+                            tokenRepository.setLoginSplash(show = true, isTokenExpired = true)
                             return@runBlocking null
                         }
 
@@ -76,7 +76,7 @@ class TokenAuthenticator
                     }
                 } catch (e: Exception) {
                     tokenRepository.clearTokens()
-                    tokenRepository.setLoginSplash(true)
+                    tokenRepository.setLoginSplash(show = true, isTokenExpired = true)
                     return@runBlocking null
                 }
             }

--- a/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
+++ b/app/src/main/java/com/byeboo/app/data/repositoryimpl/auth/TokenRepositoryImpl.kt
@@ -45,9 +45,9 @@ class TokenRepositoryImpl
             cachedAccessToken = token
         }
 
-        override suspend fun setLoginSplash(show: Boolean) {
+        override suspend fun setLoginSplash(show: Boolean, isTokenExpired: Boolean) {
             tokenDataSource.setLoginSplash(show)
-            if (show) {
+            if (isTokenExpired) {
                 _tokenExpiredEvent.tryEmit(Unit)
             }
         }

--- a/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
+++ b/app/src/main/java/com/byeboo/app/domain/repository/auth/TokenRepository.kt
@@ -20,7 +20,7 @@ interface TokenRepository {
 
     fun getCachedAccessToken(): String
 
-    suspend fun setLoginSplash(show: Boolean)
+    suspend fun setLoginSplash(show: Boolean, isTokenExpired: Boolean)
 
     suspend fun restartSplash(): Boolean
 }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/LogoutUseCase.kt
@@ -26,7 +26,7 @@ class LogoutUseCase
                 fcmTokenRepository.deleteFcmToken(FcmTokenModel(fcmToken))
                 tokenRepository.clearTokens()
                 userRepository.clear()
-                tokenRepository.setLoginSplash(true)
+                tokenRepository.setLoginSplash(show = true, isTokenExpired = false)
             }
             return logoutResult
         }

--- a/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
+++ b/app/src/main/java/com/byeboo/app/domain/usecase/WithdrawUseCase.kt
@@ -30,7 +30,7 @@ class WithdrawUseCase
             withdrawResult.onSuccess {
                 tokenRepository.clearTokens()
                 userRepository.clear()
-                tokenRepository.setLoginSplash(true)
+                tokenRepository.setLoginSplash(show = true, isTokenExpired = false)
             }
             return withdrawResult
         }

--- a/app/src/main/java/com/byeboo/app/presentation/quest/review/common/personal/detail/MyDetailAnswerViewModel.kt
+++ b/app/src/main/java/com/byeboo/app/presentation/quest/review/common/personal/detail/MyDetailAnswerViewModel.kt
@@ -9,6 +9,7 @@ import com.byeboo.app.core.util.DateUtil
 import com.byeboo.app.domain.repository.quest.QuestCommonRepository
 import com.byeboo.app.presentation.quest.component.type.MyPostOption
 import com.byeboo.app.presentation.quest.navigation.QuestMyAnswersDetail
+import com.byeboo.app.presentation.quest.util.QuestUiModelMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,6 +29,7 @@ class MyDetailAnswerViewModel
     @Inject
     constructor(
         savedStateHandle: SavedStateHandle,
+        private val mapper: QuestUiModelMapper,
         private val questCommonRepository: QuestCommonRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(MyDetailAnswerState())
@@ -83,7 +85,7 @@ class MyDetailAnswerViewModel
                                         state.answer.copy(
                                             answerId = answerId,
                                             question = detail.question,
-                                            writtenAt = detail.writtenAt.toString(),
+                                            writtenAt = mapper.formatDetailDate(detail.writtenAt),
                                             content = detail.content,
                                         ),
                                 )


### PR DESCRIPTION
## Related issue 🛠
- closed #307

## Work Description 📝
- 로그아웃, 탈퇴 시에 발생하는 앱 재실행 수정
- 나의 답변 상세 페이지 날짜 포맷 수정

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅


## PR Point 📌
- setLoginSplash은 토큰 갱신 외에도 로그아웃, 탈퇴 시에도 호출됩니다.
토큰 만료 이벤트를 함께 발행하고 있어 로그아웃, 탈퇴 시에 앱이 재실행되는 오류가 있었습니다.
`isTokenExpired` 파라미터를 추가해서 토큰 만료일 경우에만 메인 액티비티로 방출하는 것으로 수정했습니다.

- 공통퀘스트 작성 후, 캐시가 없는 상태에서 나의 답변 상세 페이지로 이동하면 날짜 포맷이 변환되지 않는 오류 수정

## 트러블 슈팅 💥


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 토큰 만료 처리 로직 개선
  * 답변 작성 날짜 표시 형식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->